### PR TITLE
send logs without the host key

### DIFF
--- a/muselog/datadog.py
+++ b/muselog/datadog.py
@@ -65,8 +65,6 @@ class DatadogJSONFormatter(json_log_formatter.JSONFormatter):
      def json_record(self, message, extra, record):
 
         extra['message'] = message
-        extra['host'] = socket.getfqdn()
-
         record_dict = dict(record.__dict__)
 
         if 'time' not in extra:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.4.1"
+VERSION = "1.4.2"
 
 install_requires = [
     "pygelf>=0.4.1",


### PR DESCRIPTION
PR: Removes host key from logs to allow `Datadog` default host key to be used instead. 
