### PR TITLE
B2B-1488  Add django request logging middleware and tests

### DIFF
--- a/muselog/django.py
+++ b/muselog/django.py
@@ -1,5 +1,5 @@
 import logging
-import datetime
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -17,23 +17,15 @@ class MuseDjangoRequestLoggingMiddleware(object):
         return response
 
     def process_request(self, request):
-        request.started_at = datetime.datetime.utcnow().timestamp()
+        request.started_at = datetime.utcnow().timestamp()
 
     def process_response(self, request, response):
         response_status = response.status_code
-        request_time = 1000.0 * datetime.datetime.utcnow().timestamp() - \
-            request.started_at
+        request_time = 1000.0 * datetime.utcnow().timestamp() - request.started_at
         request_ip = self.get_client_ip(request)
         request_summary = f"{request.method} {request.get_full_path()} ({request_ip})"
 
-        if response_status < 400:
-            log_method = self.logger.info
-        elif response_status < 500:
-            log_method = self.logger.warning
-        else:
-            log_method = self.logger.error
-
-        log_method(
+        self.logger.debug(
             "%d %s %.2fms",
             response_status,
             request_summary,

--- a/muselog/django.py
+++ b/muselog/django.py
@@ -1,0 +1,61 @@
+import logging
+import datetime
+
+logger = logging.getLogger(__name__)
+
+
+class MuseDjangoRequestLoggingMiddleware(object):
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.logger = logger
+
+    def __call__(self, request):
+        self.process_request(request)
+        response = self.get_response(request)
+        self.process_response(request, response)
+        return response
+
+    def process_request(self, request):
+        request.started_at = datetime.datetime.utcnow().timestamp()
+
+    def process_response(self, request, response):
+        response_status = response.status_code
+        request_time = 1000.0 * datetime.datetime.utcnow().timestamp() - \
+            request.started_at
+        request_ip = self.get_client_ip(request)
+        request_summary = f"{request.method} {request.get_full_path()} ({request_ip})"
+
+        if response_status < 400:
+            log_method = self.logger.info
+        elif response_status < 500:
+            log_method = self.logger.warning
+        else:
+            log_method = self.logger.error
+
+        log_method(
+            "%d %s %.2fms",
+            response_status,
+            request_summary,
+            request_time,
+            extra={
+                "request_method": request.method,
+                "request_path": request.path,
+                "request_query": request.GET.urlencode(),
+                "response_status": response_status,
+                "request_duration": request_time,
+                "request_remote_ip": request_ip,
+                "request_summary": request_summary
+            }
+        )
+
+    def get_client_ip(self, request):
+        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        if x_forwarded_for:
+            ip = x_forwarded_for.split(",")[0]
+        else:
+            ip = request.META.get("REMOTE_ADDR")
+        return ip
+
+    def set_logger(self, logger):
+        self.logger = logger

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.4.3"
+VERSION = "1.5.0"
 
 install_requires = [
     "pygelf>=0.4.1",

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -83,23 +83,9 @@ class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
         self.middleware.process_request(self.request)
         self.assertIsInstance(self.request.started_at, float)
 
-    def test_process_response_when_success(self):
-        self.logger.info = Mock()
+    def test_process_response(self):
+        self.logger.debug = Mock()
         self.response.status_code = 200
         self.request.started_at = 0
         self.middleware.process_response(self.request, self.response)
-        self.logger.info.assert_called_once()
-
-    def test_process_response_when_client_error(self):
-        self.logger.warning = Mock()
-        self.response.status_code = 404
-        self.request.started_at = 0
-        self.middleware.process_response(self.request, self.response)
-        self.logger.warning.assert_called_once()
-
-    def test_process_response_when_server_error(self):
-        self.logger.error = Mock()
-        self.response.status_code = 500
-        self.request.started_at = 0
-        self.middleware.process_response(self.request, self.response)
-        self.logger.error.assert_called_once()
+        self.logger.debug.assert_called_once()

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -1,10 +1,11 @@
 import logging
 import unittest
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import muselog
 from muselog.datadog import DataDogUdpHandler
+from muselog.django import MuseDjangoRequestLoggingMiddleware
 
 
 class SetupLoggingTestCase(unittest.TestCase):
@@ -54,3 +55,51 @@ class DataDogTestLoggingTestCase(unittest.TestCase):
 
             self.assertEqual(True, self.handler.send.called)
             self.assertEqual(cm.output, ['WARNING:datadog:Datadog msg'])
+
+
+class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = Mock()
+        self.response = Mock
+        self.request = self.get_mock_request()
+
+        def get_response():
+            self.response
+
+        self.middleware = MuseDjangoRequestLoggingMiddleware(get_response)
+        self.middleware.set_logger(self.logger)
+
+    def get_mock_request(self):
+        request = Mock()
+        request.started_at = 0
+        request.META = {
+            "HTTP_X_FORWARDED_FOR": "ip1, ip2",
+            "REMOTE_ADDR": "ip3"
+        }
+        return request
+
+    def test_process_request(self):
+        self.middleware.process_request(self.request)
+        self.assertIsInstance(self.request.started_at, float)
+
+    def test_process_response_when_success(self):
+        self.logger.info = Mock()
+        self.response.status_code = 200
+        self.request.started_at = 0
+        self.middleware.process_response(self.request, self.response)
+        self.logger.info.assert_called_once()
+
+    def test_process_response_when_client_error(self):
+        self.logger.warning = Mock()
+        self.response.status_code = 404
+        self.request.started_at = 0
+        self.middleware.process_response(self.request, self.response)
+        self.logger.warning.assert_called_once()
+
+    def test_process_response_when_server_error(self):
+        self.logger.error = Mock()
+        self.response.status_code = 500
+        self.request.started_at = 0
+        self.middleware.process_response(self.request, self.response)
+        self.logger.error.assert_called_once()


### PR DESCRIPTION
###  B2B-1488 Add django request logging middleware and tests

* Adds Django request logging middleware (very similar to tornado)
* Adds basic test cases for middleware

```python
# <my_django_project>/settings.py
​
import muselog
​
MIDDLEWARE = [
	...
	"muselog.django.BrandbuilderRequestLoggingMiddleware",
	...
]

# whatever settings make sense here
muselog.setup_logging(
    root_log_level=os.environ.get("LOG_LEVEL", "INFO"),
    module_log_levels=None,
    add_console_handler=True,
    console_handler_format=None
)
```

Let me know what you think!