### PR TITLE
PLAT-1621 include trace and span id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 venv
+.mypy_cache
+*.pyc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.1"
 services:
   test:
     image: python:3.6
-    command: bash -c "pip install -r test-requirements.txt && python -m unittest tests.test_setup_logging"
+    command: bash -c "pip install -r test-requirements.txt && python -m unittest tests.test_setup_logging tests.test_datadog_formatter"
     working_dir: /muselog
     volumes:
       - .:/muselog

--- a/muselog/__init__.py
+++ b/muselog/__init__.py
@@ -54,7 +54,7 @@ def setup_logging(root_log_level: Optional[str] = None,
 
         # log to docker for datadog if enabled. 
         if "ENABLE_DATADOG_JSON_FORMATTER" in os.environ and os.environ["ENABLE_DATADOG_JSON_FORMATTER"] == "True":
-            formatter = DatadogJSONFormatter()
+            formatter = DatadogJSONFormatter(trace_enabled=os.getenv("DATADOG_TRACE_ENABLED"))
             console_handler.setFormatter(formatter)
 
     # Add GELF handler if GELF is enabled

--- a/muselog/datadog.py
+++ b/muselog/datadog.py
@@ -87,8 +87,6 @@ class DatadogJSONFormatter(json_log_formatter.JSONFormatter):
         """
         Injects logs with a 'trace_id' and 'span_id'. If a trace is active this helps DD
         to correlate logs sent to that specific trace in APM.
-
-
         """
         if not self.trace_enabled:
             return record

--- a/muselog/datadog.py
+++ b/muselog/datadog.py
@@ -8,6 +8,7 @@ from logging.handlers import DatagramHandler
 
 import json_log_formatter
 
+from ddtrace import helpers
 
 class DataDogUdpHandler(DatagramHandler):
     """
@@ -77,10 +78,37 @@ class ObjectEncoder(json.JSONEncoder):
 
 class DatadogJSONFormatter(json_log_formatter.JSONFormatter):
 
+    trace_enabled = False
+
+    def __init__(self, trace_enabled=False):
+        self.trace_enabled = trace_enabled
+
+    def inject_trace_values(self, record):
+        """
+        Injects logs with a 'trace_id' and 'span_id'. If a trace is active this helps DD
+        to correlate logs sent to that specific trace in APM.
+
+
+        """
+        if not self.trace_enabled:
+            return record
+
+        # Create a new record so we don't modify the original
+        new_record = record.copy()
+
+        # get correlation ids from current tracer context
+        trace_id, span_id = helpers.get_correlation_ids()
+
+        new_record['dd.trace_id'] = trace_id or 0
+        new_record['dd.span_id'] = span_id or 0
+
+        return new_record
+
     def format(self, record):
         message = record.getMessage()
         json_record = self.json_record(message, record)
-        mutated_record = self.mutate_json_record(json_record)
+        trace_injected_record = self.inject_trace_values(json_record)
+        mutated_record = self.mutate_json_record(trace_injected_record)
         # Backwards compatibility: Functions that overwrite this but don't
         # return a new value will return None because they modified the
         # argument passed in.

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ VERSION = "1.6.0"
 
 install_requires = [
     "pygelf>=0.4.1",
-    "JSON-log-formatter==0.2.0",
-    "ddtrace==0.22.0" # This is the minimum version allowed as trace helpers weren't added until 0.22.0
+    "JSON-log-formatter>=0.2.0",
+    "ddtrace>=0.22.0" # This is the minimum version allowed as trace helpers weren't added until 0.22.0
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ VERSION = "1.5.2"
 install_requires = [
     "pygelf>=0.4.1",
     "JSON-log-formatter==0.2.0",
-    "ddtrace==0.12"
+    "ddtrace==0.22.0" # This is the minimum version allowed as trace helpers weren't added until 0.22.0
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.5.2"
+VERSION = "1.6.0"
 
 install_requires = [
     "pygelf>=0.4.1",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ VERSION = "1.5.2"
 
 install_requires = [
     "pygelf>=0.4.1",
-    "JSON-log-formatter==0.2.0"
+    "JSON-log-formatter==0.2.0",
+    "ddtrace==0.12"
 ]
 
 setup(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 git+git://github.com/dailymuse/pygelf.git@0.4.1#egg=pygelf
+ddtrace==0.22.0
 JSON-log-formatter==0.1.0

--- a/tests/test_datadog_formatter.py
+++ b/tests/test_datadog_formatter.py
@@ -12,7 +12,7 @@ class InjectTraceValuesTestCase(unittest.TestCase):
     def test_inject_trace_values_present(self):
         msg = "this is a test message"
         original_record = {'msg': msg}
-        dfcls = DatadogJSONFormatter()
+        dfcls = DatadogJSONFormatter(trace_enabled=True)
         modified_record = dfcls.inject_trace_values(original_record)
         self.assertDictEqual(modified_record, {'msg': msg, 'dd.trace_id': 0, 'dd.span_id': 0})
 

--- a/tests/test_datadog_formatter.py
+++ b/tests/test_datadog_formatter.py
@@ -1,0 +1,33 @@
+import logging
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+from muselog import DatadogJSONFormatter
+
+class InjectTraceValuesTestCase(unittest.TestCase):
+    """
+    Tests code related to injecting logs with a trace and span id.
+    """
+
+    def test_inject_trace_values_present(self):
+        msg = "this is a test message"
+        original_record = {'msg': msg}
+        dfcls = DatadogJSONFormatter()
+        modified_record = dfcls.inject_trace_values(original_record)
+        self.assertDictEqual(modified_record, {'msg': msg, 'dd.trace_id': 0, 'dd.span_id': 0})
+
+    def test_inject_trace_values_not_present(self):
+        """
+        If 'inject_trace_values' is not able to find the 'ddtrace' package we
+        don't want to attempt an import of 'ddtrace' and cause an error.
+        """
+        msg = "this is a test message"
+        original_record = {'msg': msg}
+        dfcls = DatadogJSONFormatter()
+
+        # Patch the 'find_spec' call to simulate the ddtrace package not existing
+        with patch('importlib.util.find_spec') as mock:
+            mock.return_value = None
+            modified_record = dfcls.inject_trace_values(original_record)
+
+        self.assertDictEqual(modified_record, original_record)

--- a/tests/test_datadog_formatter.py
+++ b/tests/test_datadog_formatter.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 from muselog import DatadogJSONFormatter
 
+
 class InjectTraceValuesTestCase(unittest.TestCase):
     """
     Tests code related to injecting logs with a trace and span id.

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -33,12 +33,6 @@ class SetupLoggingTestCase(unittest.TestCase):
         self.assertEqual(logging.getLogger("testing.child").getEffectiveLevel(), logging.CRITICAL)
         self.assertEqual(logging.getLogger("string").getEffectiveLevel(), logging.INFO)
 
-    def test_trace_and_span_id(self):
-        muselog.setup_logging(root_log_level="INFO")
-
-        logger = logging.getLogger()
-        logger.info("LOL")
-
 class DataDogTestLoggingTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -33,6 +33,11 @@ class SetupLoggingTestCase(unittest.TestCase):
         self.assertEqual(logging.getLogger("testing.child").getEffectiveLevel(), logging.CRITICAL)
         self.assertEqual(logging.getLogger("string").getEffectiveLevel(), logging.INFO)
 
+    def test_trace_and_span_id(self):
+        muselog.setup_logging(root_log_level="INFO")
+
+        logger = logging.getLogger()
+        logger.info("LOL")
 
 class DataDogTestLoggingTestCase(unittest.TestCase):
 
@@ -55,7 +60,6 @@ class DataDogTestLoggingTestCase(unittest.TestCase):
 
             self.assertEqual(True, self.handler.send.called)
             self.assertEqual(cm.output, ['WARNING:datadog:Datadog msg'])
-
 
 class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
 

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -33,6 +33,7 @@ class SetupLoggingTestCase(unittest.TestCase):
         self.assertEqual(logging.getLogger("testing.child").getEffectiveLevel(), logging.CRITICAL)
         self.assertEqual(logging.getLogger("string").getEffectiveLevel(), logging.INFO)
 
+
 class DataDogTestLoggingTestCase(unittest.TestCase):
 
     def setUp(self):
@@ -54,6 +55,7 @@ class DataDogTestLoggingTestCase(unittest.TestCase):
 
             self.assertEqual(True, self.handler.send.called)
             self.assertEqual(cm.output, ['WARNING:datadog:Datadog msg'])
+
 
 class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Injects trace and span ids in to datadog formatted json logs.

The only hard requirement of this is that app have `0.22.0`, as there is a helper function we need to use that was only added recently.

> Note: I made ddtrace a requirement in `setup.py` as trying to figure out whether ddtrace was installed or not generated a few warning messages on log that were annoying and I couldn't seem to fix it.