### PR TITLE
PLAT-1823 Use datadog standard attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 venv
 .mypy_cache
 *.pyc
+muselog.egg-info

--- a/muselog/__init__.py
+++ b/muselog/__init__.py
@@ -23,10 +23,10 @@ def setup_logging(root_log_level: Optional[str] = None,
     :param module_log_levels: A mapping of module names to their desired log levels.
     :param add_console_handler: If `True`, enable logging to stdout. (Default: `True`).
                                 Python's root_logger by default adds a StreamHandler
-                                if none is specified at app initialization, if this 
+                                if none is specified at app initialization, if this
                                 is present we want it tracked and taken out later,
-                                not to be sent to datadog (remove double entry as 
-                                it doesn't have the JSON formatter for easy interpretation on 
+                                not to be sent to datadog (remove double entry as
+                                it doesn't have the JSON formatter for easy interpretation on
                                 Datadog)
     :param console_handler_format: Specifies the format of stdout logs. (Default: `DEFAULT_LOG_FORMAT`).
     """
@@ -52,9 +52,9 @@ def setup_logging(root_log_level: Optional[str] = None,
         if default_stdout_handler is not None:
             root_logger.removeHandler(default_stdout_handler)
 
-        # log to docker for datadog if enabled. 
-        if "ENABLE_DATADOG_JSON_FORMATTER" in os.environ and os.environ["ENABLE_DATADOG_JSON_FORMATTER"] == "True":
-            formatter = DatadogJSONFormatter(trace_enabled=os.getenv("DATADOG_TRACE_ENABLED"))
+        # log to docker for datadog if enabled.
+        if "ENABLE_DATADOG_JSON_FORMATTER" in os.environ and os.environ["ENABLE_DATADOG_JSON_FORMATTER"].lower() == "true":
+            formatter = DatadogJSONFormatter(trace_enabled=os.environ.get("DATADOG_TRACE_ENABLED", "false").lower() == "true")
             console_handler.setFormatter(formatter)
 
     # Add GELF handler if GELF is enabled

--- a/muselog/datadog.py
+++ b/muselog/datadog.py
@@ -1,6 +1,7 @@
+"""Module that houses all logic necessary to send well-formed logs to Datadog."""
+
 import json
-import socket
-import traceback
+from typing import Any, Mapping
 
 from datetime import datetime, timedelta
 from logging import LogRecord
@@ -10,50 +11,46 @@ import json_log_formatter
 
 from ddtrace import helpers
 
+
 class DataDogUdpHandler(DatagramHandler):
-    """
-    A handler class which writes logging records, in pickle format, to
-    a datagram socket.  The pickle which is sent is that of the LogRecord's
-    attribute dictionary (__dict__), so that the receiver does not need to
-    have the logging module installed in order to process the logging event.
+    """A handler class which writes logging records, in pickle format, to a datagram socket.
+
+    The pickle which is sent is that of the LogRecord's attribute dictionary (__dict__),
+    so that the receiver does not need to have the logging module installed in order to process the logging event.
 
     To unpickle the record at the receiving end into a LogRecord, use the
     makeLogRecord function.
     """
 
     def __init__(self, host: str, port: int):
-        """
-        Initializes the handler with a specific host address and port.
+        """Initialize the handler with a specific host address and port.
 
         :param host: Datadog UDP input host
         :param port: Datadog UDP input port
         """
-
         super().__init__(host, port)
 
     def send(self, s: str):
-        """
-        Send a pickled string to a socket.
+        """Send a pickled string to a socket.
 
         This function no longer allows for partial sends which can happen
         when the network is busy - UDP does not guarantee delivery and
         can deliver packets out of sequence.
         """
-
         if self.sock is None:
             self.createSocket()
 
-        self.sock.sendto(bytes(s+"\n", "utf-8"), (self.host, self.port))
+        self.sock.sendto(bytes(s + "\n", "utf-8"), (self.host, self.port))
 
     def makePickle(self, record: LogRecord) -> str:
-        """
+        """Pickle the log record.
+
         Pickles the record in binary format with a length prefix, and
         returns it ready for transmission across the socket.
         """
-
         ei = record.exc_info
         if ei:
-            dummy = self.format(record) # just to get traceback text into record.exc_text
+            _ = self.format(record)  # just to get traceback text into record.exc_text
             record.exc_info = None  # to avoid Unpickleable error
         d = dict(record.__dict__)
         s = json.dumps(d)
@@ -63,7 +60,10 @@ class DataDogUdpHandler(DatagramHandler):
 
 
 class ObjectEncoder(json.JSONEncoder):
-    def default(self, obj):
+    """Class to convert an object into JSON."""
+
+    def default(self, obj: Any):
+        """Convert `obj` to JSON."""
         if hasattr(obj, "to_json"):
             return self.default(obj.to_json())
         elif hasattr(obj, "__dict__"):
@@ -73,27 +73,31 @@ class ObjectEncoder(json.JSONEncoder):
         elif isinstance(obj, timedelta):
             return obj.__str__()
         else:
-            # generic, captures all python classes irrespective. 
+            # generic, captures all python classes irrespective.
             cls = type(obj)
             result = {
-                '__custom__': True,
-                '__module__': cls.__module__,
-                '__name__': cls.__name__,
+                "__custom__": True,
+                "__module__": cls.__module__,
+                "__name__": cls.__name__,
             }
             return result
 
 
 class DatadogJSONFormatter(json_log_formatter.JSONFormatter):
+    """JSON log formatter that includes Datadog standard attributes."""
 
-    trace_enabled = False
+    def __init__(self, trace_enabled: bool = False):
+        """Create the formatter.
 
-    def __init__(self, trace_enabled=False):
+        :param trace_enabled: Set to true to include trace information in the log.
+        """
         self.trace_enabled = trace_enabled
 
-    def inject_trace_values(self, record):
-        """
-        Injects logs with a 'trace_id' and 'span_id'. If a trace is active this helps DD
-        to correlate logs sent to that specific trace in APM.
+    def inject_trace_values(self, record: LogRecord):
+        """Inject logs with a 'trace_id' and 'span_id'.
+
+        If a trace is active this helps DD to correlate logs sent to that specific
+        trace in APM.
         """
         if not self.trace_enabled:
             return record
@@ -104,12 +108,13 @@ class DatadogJSONFormatter(json_log_formatter.JSONFormatter):
         # get correlation ids from current tracer context
         trace_id, span_id = helpers.get_correlation_ids()
 
-        new_record['dd.trace_id'] = trace_id or 0
-        new_record['dd.span_id'] = span_id or 0
+        new_record["dd.trace_id"] = trace_id or 0
+        new_record["dd.span_id"] = span_id or 0
 
         return new_record
 
-    def format(self, record):
+    def format(self, record: LogRecord):
+        """Return the record in the format usable by Datadog."""
         message = record.getMessage()
         json_record = self.json_record(message, record)
         trace_injected_record = self.inject_trace_values(json_record)
@@ -121,20 +126,28 @@ class DatadogJSONFormatter(json_log_formatter.JSONFormatter):
             mutated_record = json_record
         return self.to_json(mutated_record)
 
-    def to_json(self, record):
-        """Converts record dict to a JSON string.
+    def to_json(self, record: Mapping[str, Any]):
+        """Convert record dict to a JSON string.
+
         Override this method to change the way dict is converted to JSON.
         """
         return self.json_lib.dumps(record, cls=ObjectEncoder)
 
-    def json_record(self, message, record):
-        context_obj = {}
+    def json_record(self, message: str, record: LogRecord):
+        """Convert the record to JSON and inject Datadog attributes."""
         record_dict = dict(record.__dict__)
 
-        record_dict['message'] = message
+        record_dict["message"] = message
 
+        if "time" not in record_dict:
+            record_dict["time"] = datetime.utcnow()
+        if record.exc_info:
+            record_dict["exception"] = self.formatException(record.exc_info)
+
+        # Handle non-standard attributes
         try:
             if "context" in record_dict:
+                context_obj = dict()
                 context_value = record_dict.get("context")
                 array = context_value.replace(" ", "").split(",")
                 for item in array:
@@ -147,15 +160,10 @@ class DatadogJSONFormatter(json_log_formatter.JSONFormatter):
                     context_obj[key] = int(val) if val.isdigit() else val
                     record_dict.update(context_obj)
 
-                del record_dict['context']
+                del record_dict["context"]
         except Exception as e:
             # This will allow the context come in as a regular string if it
             # it is not empty although I suspect an empty context here.
             record_dict["context_error"] = str(e)
-
-        if 'time' not in record_dict:
-            record_dict['time'] = datetime.utcnow()
-        if record.exc_info:
-            record_dict['exception'] = self.formatException(record.exc_info)
 
         return record_dict

--- a/muselog/django.py
+++ b/muselog/django.py
@@ -1,10 +1,12 @@
+"""Middleware to log django request information."""
+
 import logging
-from datetime import datetime
+import time
 
 logger = logging.getLogger(__name__)
 
 
-class MuseDjangoRequestLoggingMiddleware(object):
+class MuseDjangoRequestLoggingMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -17,28 +19,34 @@ class MuseDjangoRequestLoggingMiddleware(object):
         return response
 
     def process_request(self, request):
-        request.started_at = datetime.utcnow().timestamp()
+        request.started_at = time.time()
 
     def process_response(self, request, response):
         response_status = response.status_code
-        request_time = 1000.0 * datetime.utcnow().timestamp() - request.started_at
+        request_time = 1000 * (time.time() - request.started_at)
         request_ip = self.get_client_ip(request)
         request_summary = f"{request.method} {request.get_full_path()} ({request_ip})"
 
-        self.logger.debug(
+        if response_status < 400:
+            log_method = self.logger.info
+        elif response_status < 500:
+            log_method = self.logger.warning
+        else:
+            log_method = self.logger.error
+
+        extra = {
+            "duration": int(request_time * 1000000),
+            **self._derive_network_attrs(request, response),
+            **self._derive_http_attrs(request, response),
+            **self._derive_usr_attrs(request)
+        }
+
+        log_method(
             "%d %s %.2fms",
             response_status,
             request_summary,
             request_time,
-            extra={
-                "request_method": request.method,
-                "request_path": request.path,
-                "request_query": request.GET.urlencode(),
-                "response_status": response_status,
-                "request_duration": request_time,
-                "request_remote_ip": request_ip,
-                "request_summary": request_summary
-            }
+            extra=extra
         )
 
     def get_client_ip(self, request):
@@ -51,3 +59,51 @@ class MuseDjangoRequestLoggingMiddleware(object):
 
     def set_logger(self, logger):
         self.logger = logger
+
+    def _derive_network_attrs(self, request, response):
+        result = {
+            "network.client.ip": self.get_client_ip(request)
+            # "network.client.port": ....
+            # There is no (public) interface to get the client's port. Even if one
+            # existed, that port could be a load balancer port, whereas the remote ip
+            # is extracted from X-Forwarded-For. This would be misleading, so we do
+            # not include the client port.
+
+            # "network.destination.ip": ....
+            # The destination ip and port is not useful in this context, so
+            # we do not include it
+        }
+
+        # This is iffy, as it's unclear what network layer 'bytes_read' and 'bytes_written' refers to
+        # Still, the info is too useful to ignore, and the error is small.
+        result["network.bytes_read"] = int(request.META.get("CONTENT_LENGTH") or 0)
+        result["network.bytes_written"] = response.tell()
+
+        return result
+
+    def _derive_http_attrs(self, request, response):
+        headers = request.META
+        result = {
+            "http.url": request.get_raw_uri(),
+            "http.method": request.method,
+            "http.status_code": response.status_code,
+        }
+        request_id = headers.get("HTTP_X_REQUEST_ID") or headers.get("HTTP_X_AMZN_TRACE_ID")
+        if request_id:
+            result["http.request_id"] = request_id
+        if "HTTP_REFERER" in headers:
+            result["http.referer"] = headers["HTTP_REFERER"]
+        if "HTTP_USER_AGENT" in headers:
+            result["http.useragent"] = headers["HTTP_USER_AGENT"]
+
+        return result
+
+    def _derive_usr_attrs(self, request):
+        result = dict()
+        if not hasattr(request, "user"):
+            return result
+        user = request.user
+        if user.is_authenticated:
+            result["usr.id"] = user.id
+
+        return result

--- a/muselog/tornado.py
+++ b/muselog/tornado.py
@@ -1,17 +1,71 @@
-"""
-Helpers to log tornado request information.
-"""
+"""Helpers to log tornado request information."""
 
 import logging
 
 logger = logging.getLogger(__name__)
 
-def log_request(handler):
-    """Log the request information with extra context for use w/ Graylog-enabled apps."""
 
+def _derive_network_attrs(handler, request):
+    result = {
+        "network.client.ip": request.remote_ip,
+        # "network.client.port": ....
+        # There is no (public) interface to get the client's port. Even if one
+        # existed, that port could be a load balancer port, whereas the remote ip
+        # is extracted from X-Forwarded-For. This would be misleading, so we do
+        # not include the client port.
+
+        # "network.destination.ip": ....
+        # The destination ip and port is not useful in this context, so
+        # we do not include it
+    }
+
+    # This is iffy, as it's unclear what network layer 'bytes_read' and 'bytes_written' refers to
+    # Still, the info is too useful to ignore, and the error is small.
+    result["network.bytes_read"] = int(request.headers.get("Content-Length") or 0)
+
+    # Tornado does not save the response object, and muselog is not in the business
+    # of providing middleware at the moment. Will need to re-architect the tornado
+    # setup to work as middleware.
+    # result["network.bytes_written"] = ?
+
+    return result
+
+
+def _derive_http_attrs(handler, request):
+    headers = request.headers
+    result = {
+        "http.url": request.full_url(),
+        "http.method": request.method,
+        "http.status_code": handler.get_status(),
+    }
+    request_id = headers.get("X-Request-Id") or headers.get("X-Amzn-Trace-Id")
+    if request_id:
+        result["http.request_id"] = request_id
+    if "Referer" in headers:
+        result["http.referer"] = headers["Referer"]
+    if "User-Agent" in headers:
+        result["http.useragent"] = headers["User-Agent"]
+
+    return result
+
+
+def _derive_usr_attrs(handler):
+    result = dict()
+    user = handler.current_user
+    if user:
+        if hasattr(user, "id"):
+            result["usr.id"] = str(user.id)
+        elif isinstance(user, dict) and "id" in user:
+            result["usr.id"] = str(user["id"])
+        elif isinstance(user, str) or isinstance(user, int):
+            result["usr.id"] = str(user)
+    return result
+
+
+def log_request(handler):
+    """Log the request information with extra context."""
+    request = handler.request
     response_status = handler.get_status()
-    request_time = 1000.0 * handler.request.request_time()
-    request_summary = handler._request_summary()
 
     if response_status < 400:
         log_method = logger.info
@@ -20,11 +74,18 @@ def log_request(handler):
     else:
         log_method = logger.error
 
-    log_method("%d %s %.2fms", response_status, request_summary, request_time,
-               extra={"request_method": handler.request.method,
-                      "request_path": handler.request.path,
-                      "request_query": handler.request.query,
-                      "response_status": response_status,
-                      "request_duration": request_time,
-                      "request_remote_ip": handler.request.remote_ip,
-                      "request_summary": request_summary})
+    request_time = 1000.0 * request.request_time()
+    extra = {
+        "duration": int(request_time * 1000000),
+        **_derive_network_attrs(handler, request),
+        **_derive_http_attrs(handler, request),
+        **_derive_usr_attrs(handler)
+    }
+
+    log_method(
+        "%d %s %.2fms",
+        response_status,
+        handler._request_summary(),
+        request_time,
+        extra=extra
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup
 
-VERSION = "1.6.2"
+VERSION = "1.7.0"
 
 install_requires = [
     "pygelf>=0.4.1",
     "JSON-log-formatter>=0.2.0",
-    "ddtrace>=0.22.0" # This is the minimum version allowed as trace helpers weren't added until 0.22.0
+    "ddtrace>=0.22.0"  # This is the minimum version allowed as trace helpers weren't added until 0.22.0
 ]
 
 setup(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
+freezegun==0.3.11
+
 git+git://github.com/dailymuse/pygelf.git@0.4.1#egg=pygelf
 ddtrace==0.22.0
 JSON-log-formatter==0.1.0

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -61,7 +61,8 @@ class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
 
     def setUp(self):
         self.logger = Mock()
-        self.response = Mock
+        self.response = Mock()
+        self.response.tell.return_value = 0
         self.request = self.get_mock_request()
 
         def get_response():
@@ -77,6 +78,7 @@ class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
             "HTTP_X_FORWARDED_FOR": "ip1, ip2",
             "REMOTE_ADDR": "ip3"
         }
+        request.headers = request.META
         return request
 
     def test_process_request(self):
@@ -84,8 +86,8 @@ class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
         self.assertIsInstance(self.request.started_at, float)
 
     def test_process_response(self):
-        self.logger.debug = Mock()
+        self.logger.info = Mock()
         self.response.status_code = 200
         self.request.started_at = 0
         self.middleware.process_response(self.request, self.response)
-        self.logger.debug.assert_called_once()
+        self.logger.info.assert_called_once()


### PR DESCRIPTION
I have tested this with partners, web, and brandbuilder_v2. The tornado stuff needs to be refactored, probably. It is annoying that you need to deal with log_exception separately, and that you cannot easily extract response data (there's no way to even get headers set on the response without using a private accessor, ffs).

PLAT-1823