### PR TITLE
PLAT-1857 Set g.start on request start

### DIFF
--- a/muselog/flask.py
+++ b/muselog/flask.py
@@ -7,8 +7,6 @@ import time
 from flask import g, request
 from flask.ctx import has_request_context
 
-from werkzeug.wrappers import Request, Response
-
 logger = logging.getLogger(__name__)
 
 
@@ -44,6 +42,10 @@ def _derive_http_attrs(response=None):
     return result
 
 
+def _start_request_timer():
+    g.start = time.time()
+
+
 def _log_request(response=None):
     response_status = response.status_code if response else 500
 
@@ -63,7 +65,8 @@ def _log_request(response=None):
         **_derive_http_attrs(response)
     }
 
-    log_method("%d %s %s (%s) %.2fms",
+    log_method(
+        "%d %s %s (%s) %.2fms",
         response_status,
         request.method,
         request.full_path,
@@ -71,6 +74,7 @@ def _log_request(response=None):
         request_time,
         extra=extra
     )
+
 
 def _handle_exception(_exception):
     # Flask's documentation is confusing, and this presents a good example of why stackoverflow
@@ -106,5 +110,6 @@ def register_muselog_request_hooks(app):
     ...
     ```
     """
+    app.before_request(_start_request_timer)
     app.after_request(_log_request)
     app.teardown_request(_handle_exception)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.8.0"
+VERSION = "1.8.1"
 
 install_requires = [
     "pygelf>=0.4.1",


### PR DESCRIPTION
Merging this because it's messing up rex. I didn't catch it in the tests since rex wouldnt work locally to integration test... and muselog sets g.start manually in its tests.

PLAT-1857