### PR TITLE
PLAT-1860 Ensure consistency across all middlewares

### DIFF
--- a/muselog/attributes.py
+++ b/muselog/attributes.py
@@ -1,0 +1,127 @@
+"""Helper functions useful to multiple middlewares."""
+
+from abc import ABC, abstractmethod
+from ipaddress import ip_address
+from urllib.parse import urlparse
+
+from typing import Any, Callable, Dict, Optional, Tuple
+
+
+class Attributes(ABC):
+    """Abstract class representing any attributes that also have a standard, dictionary form."""
+
+    @abstractmethod
+    def standardize(self) -> Dict[str, Any]:
+        """Return the standard format for the attributes."""
+        return dict()
+
+
+class NetworkAttributes(Attributes):
+    """Normalized form of network attributes."""
+
+    def __init__(self,
+                 extract_header: Callable[[str], Any],
+                 remote_addr: Optional[str] = None,
+                 bytes_read: Optional[int] = None,
+                 bytes_written: Optional[int] = None) -> None:
+        """Populate network attributes.
+
+        :param extract_header:  Framework-agnostic callable that returns the value
+                                of the provided request header.
+        :param remote_addr:     IPv4/v6 and optional port (delimitted by ':') of the
+                                client /machine/ that is connected to the server. This
+                                address may not be the same as the machine that initiated the
+                                request.
+        :param bytes_read:      Number of bytes the server has read from the client request.
+                                This number refers to the size of the request's message entity,
+                                which is indicated by Content-Length in most cases.
+        :param bytes_written:   Number of bytes the server has written to the client.
+                                This number refers to the size of the response's message entity.
+
+        """
+        self.remote_addr = remote_addr
+        self.client_ip, self.client_port = self._derive_client_host(extract_header)
+        self.bytes_read = int(bytes_read or 0)
+        self.bytes_written = int(bytes_written or 0)
+
+    def _derive_client_host(self, extract_header: Callable[[str], Any]) -> Tuple[Optional[str], Optional[str]]:
+        ip = extract_header("Cf-Connecting-Ip") or extract_header("True-Client-Ip") or self._resolve_forwarded(extract_header) or self.remote_addr
+
+        if not ip:
+            ip, port = None, None
+        elif ":" not in ip:
+            ip, port = ip, None
+        else:
+            # Could be ipv4 w/ port, or ipv6 (w/ or w/o port). Best to just parse it.
+            try:
+                ip = str(ip_address(ip))
+                port = None
+            except ValueError:
+                parsed = urlparse(f"//{ip}")
+                ip = str(ip_address(parsed.hostname))
+                port = str(parsed.port)
+
+        return ip, port
+
+    def _resolve_forwarded(self, extract_header: Callable[[str], Any]) -> Optional[str]:
+        forwarded_ip_list = extract_header("Forwarded") or extract_header("X-Forwarded-For") or ""
+        forwarded_ip_list = forwarded_ip_list.replace(" ", "")
+        return forwarded_ip_list.split(",")[0] if forwarded_ip_list else None
+
+    def standardize(self) -> Dict[str, Any]:
+        """See :func:`Attributes.standardize`."""
+        result = dict()
+
+        if self.client_ip:
+            result["network.client.ip"] = self.client_ip
+        if self.client_port:
+            result["network.client.port"] = self.client_port
+        result["network.bytes_read"] = self.bytes_read
+        result["network.bytes_written"] = self.bytes_written
+
+        return result
+
+
+class HttpAttributes(Attributes):
+    """Normalized form of http attributes."""
+
+    def __init__(self,
+                 extract_header: Callable[[str], Any],
+                 url: str,
+                 method: str,
+                 status_code: int) -> None:
+        """Populate http attributes.
+
+        :param extract_header:  Framework-agnostic callable that returns the value
+                                of the provided request header.
+        :param url:             Full request URL. This should be the url exactly
+                                as the client sent it. Also permissible: framework-specific
+                                sanitized version of the url.
+        :param method:          Request method in capital letters (GET, PUT, PATCH, ...).
+        :param status_code:     Response status code.
+        """
+        self.url = url
+        self.method = method
+        self.status_code = status_code
+        self.request_id = extract_header("X-Request-Id") or extract_header("X-Amzn-Trace-Id")
+        self.referrer = extract_header("Referer")
+        self.user_agent = extract_header("User-Agent")
+
+    def standardize(self) -> Dict[str, Any]:
+        """See :func:`Attributes.standardize`."""
+        result = {
+            "http.url": self.url,
+            "http.method": self.method,
+            "http.status_code": self.status_code
+        }
+
+        if self.request_id:
+            result["http.request_id"] = self.request_id
+
+        if self.referrer:
+            result["http.referer"] = self.referrer
+
+        if self.user_agent:
+            result["http.useragent"] = self.user_agent
+
+        return result

--- a/muselog/django.py
+++ b/muselog/django.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Mapping, Optional, Union
 
 from django.http import HttpRequest, HttpResponse
 
-from . import util
+from . import attributes, util
 
 
 def _extract_header(meta: Mapping[str, Any]) -> Callable[[str], Any]:
@@ -59,13 +59,13 @@ class MuseDjangoRequestLoggingMiddleware:
         """Extract and log timing, network, http, and user attributes."""
         meta = request.META
         extract_header = _extract_header(meta)
-        network_attrs = util.NetworkAttributes(
+        network_attrs = attributes.NetworkAttributes(
             extract_header=extract_header,
             remote_addr=meta.get("REMOTE_ADDR"),
             bytes_read=meta.get("CONTENT_LENGTH"),
             bytes_written=response.tell()
         )
-        http_attrs = util.HttpAttributes(
+        http_attrs = attributes.HttpAttributes(
             extract_header=extract_header,
             url=request.get_raw_uri(),
             method=request.method,

--- a/muselog/django.py
+++ b/muselog/django.py
@@ -1,112 +1,90 @@
-"""Middleware to log django request information."""
+"""Helpers to log requests processed within the Django web framework."""
 
-import logging
-import sys
 import time
+from typing import Any, Callable, Mapping, Optional, Union
 
-logger = logging.getLogger(__name__)
+from django.http import HttpRequest, HttpResponse
+
+from . import util
+
+
+def _extract_header(meta: Mapping[str, Any]) -> Callable[[str], Any]:
+    """For use by the attribute classes, which require a framework-agnostic header function."""
+    def _get(header: str, default=None) -> Optional[Any]:
+        header = header.replace('-', '_').upper()
+        if header not in ("CONTENT_TYPE", "CONTENT_LENGTH"):
+            header = f"HTTP_{header}"
+        return meta.get(header, default)
+    return _get
 
 
 class MuseDjangoRequestLoggingMiddleware:
+    """Middleware to log django request information.
 
-    def __init__(self, get_response):
+    Add to your MIDDLEWARE list in your Django settings file, like so:
+    ```
+    MIDDLEWARE = [
+        ...
+        "muselog.django.MuseDjangoRequestLoggingMiddleware",
+        ...
+    ]
+    ```
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        """Configure the middleware.
+
+        :param get_response: Callable provided by Django to get response from next middleware or view.
+
+        """
         self.get_response = get_response
-        self.logger = logger
 
-    def __call__(self, request):
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        """Execute middleware logic and return the response.
+
+        This middleware modifies the request in order to calculate its duration.
+        It does not modify the response.
+
+        """
         self.process_request(request)
         response = self.get_response(request)
         self.process_response(request, response)
         return response
 
-    def process_request(self, request):
+    def process_request(self, request: HttpRequest) -> None:
+        """Add timing information to the request to calculate its duration."""
         request.started_at = time.time()
 
-    def process_response(self, request, response):
-        response_status = response.status_code
-        request_time = 1000 * (time.time() - request.started_at)
-        request_ip = self.get_client_ip(request)
-        request_summary = f"{request.method} {request.get_full_path()} ({request_ip})"
-
-        if response_status < 400:
-            log_method = self.logger.info
-        elif response_status < 500:
-            log_method = self.logger.warning
-        elif not sys.exc_info()[0]:
-            log_method = self.logger.error
-        else:
-            log_method = self.logger.exception
-
-        extra = {
-            "duration": int(request_time * 1000000),
-            **self._derive_network_attrs(request, response),
-            **self._derive_http_attrs(request, response),
-            **self._derive_usr_attrs(request)
-        }
-
-        log_method(
-            "%d %s %.2fms",
-            response_status,
-            request_summary,
-            request_time,
-            extra=extra
+    def process_response(self, request: HttpRequest, response: HttpResponse) -> None:
+        """Extract and log timing, network, http, and user attributes."""
+        meta = request.META
+        extract_header = _extract_header(meta)
+        network_attrs = util.NetworkAttributes(
+            extract_header=extract_header,
+            remote_addr=meta.get("REMOTE_ADDR"),
+            bytes_read=meta.get("CONTENT_LENGTH"),
+            bytes_written=response.tell()
+        )
+        http_attrs = util.HttpAttributes(
+            extract_header=extract_header,
+            url=request.get_raw_uri(),
+            method=request.method,
+            status_code=response.status_code
+        )
+        util.log_request(
+            request.get_full_path(),
+            time.time() - request.started_at,
+            network_attrs,
+            http_attrs,
+            user_id=self._get_user_id(request)
         )
 
-    def get_client_ip(self, request):
-        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-        if x_forwarded_for:
-            ip = x_forwarded_for.split(",")[0]
-        else:
-            ip = request.META.get("REMOTE_ADDR")
-        return ip
-
-    def set_logger(self, logger):
-        self.logger = logger
-
-    def _derive_network_attrs(self, request, response):
-        result = {
-            "network.client.ip": self.get_client_ip(request)
-            # "network.client.port": ....
-            # There is no (public) interface to get the client's port. Even if one
-            # existed, that port could be a load balancer port, whereas the remote ip
-            # is extracted from X-Forwarded-For. This would be misleading, so we do
-            # not include the client port.
-
-            # "network.destination.ip": ....
-            # The destination ip and port is not useful in this context, so
-            # we do not include it
-        }
-
-        # This is iffy, as it's unclear what network layer 'bytes_read' and 'bytes_written' refers to
-        # Still, the info is too useful to ignore, and the error is small.
-        result["network.bytes_read"] = int(request.META.get("CONTENT_LENGTH") or 0)
-        result["network.bytes_written"] = response.tell()
-
-        return result
-
-    def _derive_http_attrs(self, request, response):
-        headers = request.META
-        result = {
-            "http.url": request.get_raw_uri(),
-            "http.method": request.method,
-            "http.status_code": response.status_code,
-        }
-        request_id = headers.get("HTTP_X_REQUEST_ID") or headers.get("HTTP_X_AMZN_TRACE_ID")
-        if request_id:
-            result["http.request_id"] = request_id
-        if "HTTP_REFERER" in headers:
-            result["http.referer"] = headers["HTTP_REFERER"]
-        if "HTTP_USER_AGENT" in headers:
-            result["http.useragent"] = headers["HTTP_USER_AGENT"]
-
-        return result
-
-    def _derive_usr_attrs(self, request):
-        result = dict()
+    @staticmethod
+    def _get_user_id(request: HttpRequest) -> Optional[Union[str, int]]:
         if not hasattr(request, "user"):
-            return result
+            return None
         user = request.user
         if user.is_authenticated:
-            result["usr.id"] = user.id
-
-        return result
+            return user.id
+        else:
+            return None

--- a/muselog/flask.py
+++ b/muselog/flask.py
@@ -7,7 +7,7 @@ from flask import g, request, Flask
 from flask.ctx import has_request_context
 from flask.wrappers import Response
 
-from . import util
+from . import attributes, util
 
 
 def _start_request_timer() -> None:
@@ -15,13 +15,13 @@ def _start_request_timer() -> None:
 
 
 def _log_request(response: Optional[Response] = None) -> None:
-    network_attrs = util.NetworkAttributes(
+    network_attrs = attributes.NetworkAttributes(
         extract_header=request.headers.get,
         remote_addr=request.remote_addr,
         bytes_read=request.content_length,
         bytes_written=response.calculate_content_length() if response else None
     )
-    http_attrs = util.HttpAttributes(
+    http_attrs = attributes.HttpAttributes(
         extract_header=request.headers.get,
         url=request.url,
         method=request.method,

--- a/muselog/flask.py
+++ b/muselog/flask.py
@@ -1,84 +1,36 @@
 """Middleware that flask applications use to enable datadog-compatible request logging."""
 
-import logging
-import sys
 import time
+from typing import Optional
 
-from flask import g, request
+from flask import g, request, Flask
 from flask.ctx import has_request_context
+from flask.wrappers import Response
 
-logger = logging.getLogger(__name__)
-
-
-def _derive_network_attrs(response=None):
-    result = dict()
-    if request.remote_addr:
-        result["network.client.ip"] = request.remote_addr
-
-    # This is iffy, as it's unclear what network layer 'bytes_read' and 'bytes_written' refers to
-    # Still, the info is too useful to ignore, and the error is small.
-    result["network.bytes_read"] = int(request.content_length or 0)
-    if response:
-        result["network.bytes_written"] = response.calculate_content_length() or 0
-
-    return result
+from . import util
 
 
-def _derive_http_attrs(response=None):
-    headers = request.headers
-    result = {
-        "http.url": request.url,
-        "http.method": request.method,
-        "http.status_code": response.status_code if response else 500,
-    }
-    request_id = headers.get("X-Request-Id") or headers.get("X-Amzn-Trace-Id")
-    if request_id:
-        result["http.request_id"] = request_id
-    if request.referrer:
-        result["http.referer"] = request.referrer
-    if request.user_agent:
-        result["http.useragent"] = request.user_agent
-
-    return result
-
-
-def _start_request_timer():
+def _start_request_timer() -> None:
     g.start = time.time()
 
 
-def _log_request(response=None):
-    response_status = response.status_code if response else 500
-
-    if response_status < 400:
-        log_method = logger.info
-    elif response_status < 500:
-        log_method = logger.warning
-    elif not sys.exc_info()[0]:
-        log_method = logger.error
-    else:
-        log_method = logger.exception
-
-    request_time = 1000.0 * (time.time() - g.start)
-    extra = {
-        "duration": int(request_time * 1000000),
-        **_derive_network_attrs(response),
-        **_derive_http_attrs(response)
-    }
-
-    log_method(
-        "%d %s %s (%s) %.2fms",
-        response_status,
-        request.method,
-        request.full_path,
-        request.remote_addr or "?",
-        request_time,
-        extra=extra
+def _log_request(response: Optional[Response] = None) -> None:
+    network_attrs = util.NetworkAttributes(
+        extract_header=request.headers.get,
+        remote_addr=request.remote_addr,
+        bytes_read=request.content_length,
+        bytes_written=response.calculate_content_length() if response else None
     )
+    http_attrs = util.HttpAttributes(
+        extract_header=request.headers.get,
+        url=request.url,
+        method=request.method,
+        status_code=response.status_code if response else 500
+    )
+    util.log_request(request.full_path, time.time() - g.start, network_attrs, http_attrs)
 
-    return response
 
-
-def _handle_exception(_exception):
+def _handle_exception(_exception: Exception) -> None:
     # Flask's documentation is confusing, and this presents a good example of why stackoverflow
     # should *not* be trusted. Users on stackoverflow claim that request context is not available
     # during teardown_request, but this is not true. teardown_request is called immediately before
@@ -102,7 +54,7 @@ def _handle_exception(_exception):
     _log_request()
 
 
-def register_muselog_request_hooks(app):
+def register_muselog_request_hooks(app: Flask) -> None:
     """Hookup muselog to flask's request lifecycle.
 
     Call immediately after instantiating the Flask application object. For example,

--- a/muselog/tornado.py
+++ b/muselog/tornado.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 
 from tornado.web import RequestHandler
 
-from . import util
+from . import attributes, util
 
 
 def _get_user_id(handler: RequestHandler) -> Optional[Union[str, int]]:
@@ -23,12 +23,12 @@ def _get_user_id(handler: RequestHandler) -> Optional[Union[str, int]]:
 def log_request(handler: RequestHandler) -> None:
     """Log the request information with extra context."""
     request = handler.request
-    network_attrs = util.NetworkAttributes(
+    network_attrs = attributes.NetworkAttributes(
         extract_header=request.headers.get,
         remote_addr=request.remote_ip,
         bytes_read=request.headers.get("Content-Length")
     )
-    http_attrs = util.HttpAttributes(
+    http_attrs = attributes.HttpAttributes(
         extract_header=request.headers.get,
         url=request.full_url(),
         method=request.method,

--- a/muselog/tornado.py
+++ b/muselog/tornado.py
@@ -1,94 +1,43 @@
 """Helpers to log tornado request information."""
 
-import logging
-import sys
+from typing import Optional, Union
 
-logger = logging.getLogger(__name__)
+from tornado.web import RequestHandler
 
-
-def _derive_network_attrs(handler, request):
-    result = {
-        "network.client.ip": request.remote_ip,
-        # "network.client.port": ....
-        # There is no (public) interface to get the client's port. Even if one
-        # existed, that port could be a load balancer port, whereas the remote ip
-        # is extracted from X-Forwarded-For. This would be misleading, so we do
-        # not include the client port.
-
-        # "network.destination.ip": ....
-        # The destination ip and port is not useful in this context, so
-        # we do not include it
-    }
-
-    # This is iffy, as it's unclear what network layer 'bytes_read' and 'bytes_written' refers to
-    # Still, the info is too useful to ignore, and the error is small.
-    result["network.bytes_read"] = int(request.headers.get("Content-Length") or 0)
-
-    # Tornado does not save the response object, and muselog is not in the business
-    # of providing middleware at the moment. Will need to re-architect the tornado
-    # setup to work as middleware.
-    # result["network.bytes_written"] = ?
-
-    return result
+from . import util
 
 
-def _derive_http_attrs(handler, request):
-    headers = request.headers
-    result = {
-        "http.url": request.full_url(),
-        "http.method": request.method,
-        "http.status_code": handler.get_status(),
-    }
-    request_id = headers.get("X-Request-Id") or headers.get("X-Amzn-Trace-Id")
-    if request_id:
-        result["http.request_id"] = request_id
-    if "Referer" in headers:
-        result["http.referer"] = headers["Referer"]
-    if "User-Agent" in headers:
-        result["http.useragent"] = headers["User-Agent"]
-
-    return result
-
-
-def _derive_usr_attrs(handler):
-    result = dict()
+def _get_user_id(handler: RequestHandler) -> Optional[Union[str, int]]:
+    user_id = None
     user = handler.current_user
     if user:
         if hasattr(user, "id"):
-            result["usr.id"] = str(user.id)
+            user_id = user.id
         elif isinstance(user, dict) and "id" in user:
-            result["usr.id"] = str(user["id"])
+            user_id = user["id"]
         elif isinstance(user, str) or isinstance(user, int):
-            result["usr.id"] = str(user)
-    return result
+            user_id = user
+    return user_id
 
 
-def log_request(handler):
+def log_request(handler: RequestHandler) -> None:
     """Log the request information with extra context."""
     request = handler.request
-    response_status = handler.get_status()
-
-    if response_status < 400:
-        log_method = logger.info
-    elif response_status < 500:
-        log_method = logger.warning
-    elif not sys.exc_info()[0]:
-        log_method = logger.error
-    else:
-        log_method = logger.exception
-
-    request_time = 1000.0 * request.request_time()
-    extra = {
-        "duration": int(request_time * 1000000),
-        **_derive_network_attrs(handler, request),
-        **_derive_http_attrs(handler, request),
-        **_derive_usr_attrs(handler)
-    }
-
-    log_method(
-        "%d %s %.2fms",
-        response_status,
-        handler._request_summary(),
-        request_time,
-        extra=extra
+    network_attrs = util.NetworkAttributes(
+        extract_header=request.headers.get,
+        remote_addr=request.remote_ip,
+        bytes_read=request.headers.get("Content-Length")
+    )
+    http_attrs = util.HttpAttributes(
+        extract_header=request.headers.get,
+        url=request.full_url(),
+        method=request.method,
+        status_code=handler.get_status()
+    )
+    util.log_request(
+        request.uri,
+        request.request_time(),
+        network_attrs,
+        http_attrs,
+        user_id=_get_user_id(handler)
     )

--- a/muselog/util.py
+++ b/muselog/util.py
@@ -1,0 +1,174 @@
+"""Helper functions useful to multiple middlewares."""
+
+from abc import ABC, abstractmethod
+from ipaddress import ip_address
+import logging
+import sys
+from urllib.parse import urlparse
+
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+
+logger = logging.getLogger(__name__)
+
+
+class Attributes(ABC):
+    """Abstract class representing any attributes that also have a standard, dictionary form."""
+
+    @abstractmethod
+    def standardize(self) -> Dict[str, Any]:
+        """Return the standard format for the attributes."""
+        return dict()
+
+
+class NetworkAttributes(Attributes):
+    """Normalized form of network attributes."""
+
+    def __init__(self,
+                 extract_header: Callable[[str], Any],
+                 remote_addr: Optional[str] = None,
+                 bytes_read: Optional[int] = None,
+                 bytes_written: Optional[int] = None) -> None:
+        """Populate network attributes.
+
+        :param extract_header:  Framework-agnostic callable that returns the value
+                                of the provided request header.
+        :param remote_addr:     IPv4/v6 and optional port (delimitted by ':') of the
+                                client /machine/ that is connected to the server. This
+                                address may not be the same as the machine that initiated the
+                                request.
+        :param bytes_read:      Number of bytes the server has read from the client request.
+                                This number refers to the size of the request's message entity,
+                                which is indicated by Content-Length in most cases.
+        :param bytes_written:   Number of bytes the server has written to the client.
+                                This number refers to the size of the response's message entity.
+
+        """
+        self.remote_addr = remote_addr
+        self.client_ip, self.client_port = self._derive_client_host(extract_header)
+        self.bytes_read = int(bytes_read or 0)
+        self.bytes_written = int(bytes_written or 0)
+
+    def _derive_client_host(self, extract_header: Callable[[str], Any]) -> Tuple[Optional[str], Optional[str]]:
+        ip = extract_header("Cf-Connecting-Ip") or extract_header("True-Client-Ip") or self._resolve_forwarded(extract_header) or self.remote_addr
+
+        if not ip:
+            ip, port = None, None
+        elif ":" not in ip:
+            ip, port = ip, None
+        else:
+            # Could be ipv4 w/ port, or ipv6 (w/ or w/o port). Best to just parse it.
+            try:
+                ip = str(ip_address(ip))
+                port = None
+            except ValueError:
+                parsed = urlparse(f"//{ip}")
+                ip = str(ip_address(parsed.hostname))
+                port = str(parsed.port)
+
+        return ip, port
+
+    def _resolve_forwarded(self, extract_header: Callable[[str], Any]) -> Optional[str]:
+        forwarded_ip_list = extract_header("Forwarded") or extract_header("X-Forwarded-For") or ""
+        forwarded_ip_list = forwarded_ip_list.replace(" ", "")
+        return forwarded_ip_list.split(",")[0] if forwarded_ip_list else None
+
+    def standardize(self) -> Dict[str, Any]:
+        """See :func:`Attributes.standardize`."""
+        result = dict()
+
+        if self.client_ip:
+            result["network.client.ip"] = self.client_ip
+        if self.client_port:
+            result["network.client.port"] = self.client_port
+        result["network.bytes_read"] = self.bytes_read
+        result["network.bytes_written"] = self.bytes_written
+
+        return result
+
+
+class HttpAttributes(Attributes):
+    """Normalized form of http attributes."""
+
+    def __init__(self,
+                 extract_header: Callable[[str], Any],
+                 url: str,
+                 method: str,
+                 status_code: int) -> None:
+        """Populate http attributes.
+
+        :param extract_header:  Framework-agnostic callable that returns the value
+                                of the provided request header.
+        :param url:             Full request URL. This should be the url exactly
+                                as the client sent it. Also permissible: framework-specific
+                                sanitized version of the url.
+        :param method:          Request method in capital letters (GET, PUT, PATCH, ...).
+        :param status_code:     Response status code.
+        """
+        self.url = url
+        self.method = method
+        self.status_code = status_code
+        self.request_id = extract_header("X-Request-Id") or extract_header("X-Amzn-Trace-Id")
+        self.referrer = extract_header("Referer")
+        self.user_agent = extract_header("User-Agent")
+
+    def standardize(self) -> Dict[str, Any]:
+        """See :func:`Attributes.standardize`."""
+        result = {
+            "http.url": self.url,
+            "http.method": self.method,
+            "http.status_code": self.status_code
+        }
+
+        if self.request_id:
+            result["http.request_id"] = self.request_id
+
+        if self.referrer:
+            result["http.referer"] = self.referrer
+
+        if self.user_agent:
+            result["http.useragent"] = self.user_agent
+
+        return result
+
+
+def log_request(path: str,
+                duration_secs: int,
+                network_attrs: NetworkAttributes,
+                http_attrs: HttpAttributes,
+                user_id: Optional[Union[str, int]] = None):
+    """Log the provided request information in a standardized format.
+
+    :param duration_secs:   Seconds spent processing the request.
+    :param network_attrs:   See :class:`NetworkAttributes`
+    :param http_attrs:      See :class:`HttpAttributes`
+    :param user_id:         GDPR-compliant (not a name, username, or email) user identifier, if available.
+    """
+    status_code = http_attrs.status_code
+    if status_code < 400:
+        log_method = logger.info
+    elif status_code < 500:
+        log_method = logger.warning
+    elif not sys.exc_info()[0]:
+        log_method = logger.error
+    else:
+        log_method = logger.exception
+
+    duration_ms = duration_secs * 1000
+    extra = {
+        "duration": duration_ms * 1000000,
+        **network_attrs.standardize(),
+        **http_attrs.standardize()
+    }
+    if user_id:
+        extra["usr.id"] = user_id
+
+    log_method(
+        "%d %s %s (%s) %.2fms",
+        status_code,
+        http_attrs.method,
+        path,
+        network_attrs.client_ip or "?",
+        duration_ms,
+        extra=extra
+    )

--- a/muselog/util.py
+++ b/muselog/util.py
@@ -1,135 +1,13 @@
 """Helper functions useful to multiple middlewares."""
 
-from abc import ABC, abstractmethod
-from ipaddress import ip_address
 import logging
 import sys
-from urllib.parse import urlparse
 
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Optional, Union
 
+from .attributes import NetworkAttributes, HttpAttributes
 
 logger = logging.getLogger(__name__)
-
-
-class Attributes(ABC):
-    """Abstract class representing any attributes that also have a standard, dictionary form."""
-
-    @abstractmethod
-    def standardize(self) -> Dict[str, Any]:
-        """Return the standard format for the attributes."""
-        return dict()
-
-
-class NetworkAttributes(Attributes):
-    """Normalized form of network attributes."""
-
-    def __init__(self,
-                 extract_header: Callable[[str], Any],
-                 remote_addr: Optional[str] = None,
-                 bytes_read: Optional[int] = None,
-                 bytes_written: Optional[int] = None) -> None:
-        """Populate network attributes.
-
-        :param extract_header:  Framework-agnostic callable that returns the value
-                                of the provided request header.
-        :param remote_addr:     IPv4/v6 and optional port (delimitted by ':') of the
-                                client /machine/ that is connected to the server. This
-                                address may not be the same as the machine that initiated the
-                                request.
-        :param bytes_read:      Number of bytes the server has read from the client request.
-                                This number refers to the size of the request's message entity,
-                                which is indicated by Content-Length in most cases.
-        :param bytes_written:   Number of bytes the server has written to the client.
-                                This number refers to the size of the response's message entity.
-
-        """
-        self.remote_addr = remote_addr
-        self.client_ip, self.client_port = self._derive_client_host(extract_header)
-        self.bytes_read = int(bytes_read or 0)
-        self.bytes_written = int(bytes_written or 0)
-
-    def _derive_client_host(self, extract_header: Callable[[str], Any]) -> Tuple[Optional[str], Optional[str]]:
-        ip = extract_header("Cf-Connecting-Ip") or extract_header("True-Client-Ip") or self._resolve_forwarded(extract_header) or self.remote_addr
-
-        if not ip:
-            ip, port = None, None
-        elif ":" not in ip:
-            ip, port = ip, None
-        else:
-            # Could be ipv4 w/ port, or ipv6 (w/ or w/o port). Best to just parse it.
-            try:
-                ip = str(ip_address(ip))
-                port = None
-            except ValueError:
-                parsed = urlparse(f"//{ip}")
-                ip = str(ip_address(parsed.hostname))
-                port = str(parsed.port)
-
-        return ip, port
-
-    def _resolve_forwarded(self, extract_header: Callable[[str], Any]) -> Optional[str]:
-        forwarded_ip_list = extract_header("Forwarded") or extract_header("X-Forwarded-For") or ""
-        forwarded_ip_list = forwarded_ip_list.replace(" ", "")
-        return forwarded_ip_list.split(",")[0] if forwarded_ip_list else None
-
-    def standardize(self) -> Dict[str, Any]:
-        """See :func:`Attributes.standardize`."""
-        result = dict()
-
-        if self.client_ip:
-            result["network.client.ip"] = self.client_ip
-        if self.client_port:
-            result["network.client.port"] = self.client_port
-        result["network.bytes_read"] = self.bytes_read
-        result["network.bytes_written"] = self.bytes_written
-
-        return result
-
-
-class HttpAttributes(Attributes):
-    """Normalized form of http attributes."""
-
-    def __init__(self,
-                 extract_header: Callable[[str], Any],
-                 url: str,
-                 method: str,
-                 status_code: int) -> None:
-        """Populate http attributes.
-
-        :param extract_header:  Framework-agnostic callable that returns the value
-                                of the provided request header.
-        :param url:             Full request URL. This should be the url exactly
-                                as the client sent it. Also permissible: framework-specific
-                                sanitized version of the url.
-        :param method:          Request method in capital letters (GET, PUT, PATCH, ...).
-        :param status_code:     Response status code.
-        """
-        self.url = url
-        self.method = method
-        self.status_code = status_code
-        self.request_id = extract_header("X-Request-Id") or extract_header("X-Amzn-Trace-Id")
-        self.referrer = extract_header("Referer")
-        self.user_agent = extract_header("User-Agent")
-
-    def standardize(self) -> Dict[str, Any]:
-        """See :func:`Attributes.standardize`."""
-        result = {
-            "http.url": self.url,
-            "http.method": self.method,
-            "http.status_code": self.status_code
-        }
-
-        if self.request_id:
-            result["http.request_id"] = self.request_id
-
-        if self.referrer:
-            result["http.referer"] = self.referrer
-
-        if self.user_agent:
-            result["http.useragent"] = self.user_agent
-
-        return result
 
 
 def log_request(path: str,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.8.2"
+VERSION = "1.8.3"
 
 install_requires = [
     "pygelf>=0.4.1",
@@ -18,6 +18,8 @@ setup(
 
     install_requires=install_requires,
     extras_require={
-        "flask": ["Flask>=1.0.2"]
+        "django": ["Django>=2.1.2"],
+        "flask": ["Flask>=1.0.2"],
+        "tornado": ["tornado>=4.5.1"]
     }
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,7 @@
 freezegun==0.3.11
 Flask==1.0.2
+Django==2.1.2
+tornado==4.5.1
 
 git+git://github.com/dailymuse/pygelf.git@0.4.1#egg=pygelf
 ddtrace==0.22.0

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,117 @@
+import unittest
+
+from muselog import attributes
+
+
+class NetworkAttributesTestCase(unittest.TestCase):
+
+    def test_standardize_forward_header_priority(self):
+        headers = {
+            "True-Client-Ip": "123.22.11.59",
+            "Forwarded": "12.22.11.50,54.56.129.12",
+            "X-Forwarded-For": "90.32.53.8,12.22.11.50,54.56.129.12"
+        }
+        network_attrs = attributes.NetworkAttributes(extract_header=headers.get, remote_addr="99.58.39.5")
+        result = network_attrs.standardize()
+
+        # Prefer cloudflare if available
+        self.assertEqual(result["network.client.ip"], "123.22.11.59")
+
+        del headers["True-Client-Ip"]
+
+        network_attrs = attributes.NetworkAttributes(extract_header=headers.get, remote_addr="99.58.39.5")
+        result = network_attrs.standardize()
+
+        # Prefer Forwarded if cloudflare unavailable
+        self.assertEqual(result["network.client.ip"], "12.22.11.50")
+
+        del headers["Forwarded"]
+
+        network_attrs = attributes.NetworkAttributes(extract_header=headers.get, remote_addr="99.58.39.5")
+        result = network_attrs.standardize()
+
+        # Use X-Forwarded-For as last resort before falling back to remote addr
+        self.assertEqual(result["network.client.ip"], "90.32.53.8")
+
+    def test_standardize_without_extra_headers(self):
+        network_attrs = attributes.NetworkAttributes(
+            extract_header=lambda _: None,
+            remote_addr="99.58.39.5",
+            bytes_read=10,
+            bytes_written=5
+        )
+        result = network_attrs.standardize()
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result["network.client.ip"], "99.58.39.5")
+        self.assertEqual(result["network.bytes_read"], 10)
+        self.assertEqual(result["network.bytes_written"], 5)
+
+    def test_standardize_remote_addr_with_port(self):
+        network_attrs = attributes.NetworkAttributes(
+            extract_header=lambda _: None,
+            remote_addr="99.58.39.5:80"
+        )
+        result = network_attrs.standardize()
+        self.assertEqual(result["network.client.ip"], "99.58.39.5")
+        self.assertEqual(result["network.client.port"], "80")
+
+    def test_standardize_remote_addr_ipv6(self):
+        network_attrs = attributes.NetworkAttributes(
+            extract_header=lambda _: None,
+            remote_addr="2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        )
+        result = network_attrs.standardize()
+        # Should get short form of ipv6 back
+        self.assertEqual(result["network.client.ip"], "2001:db8:85a3::8a2e:370:7334")
+
+    def test_standardize_remote_addr_ipv6_with_port(self):
+        network_attrs = attributes.NetworkAttributes(
+            extract_header=lambda _: None,
+            remote_addr="[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443"
+        )
+        result = network_attrs.standardize()
+        # Should get short form of ipv6 back, and brackets should be removed.
+        self.assertEqual(result["network.client.ip"], "2001:db8:85a3::8a2e:370:7334")
+        self.assertEqual(result["network.client.port"], "443")
+
+
+class HttpAttributesTestCase(unittest.TestCase):
+
+    def test_standardize_without_extra_headers(self):
+        http_attrs = attributes.HttpAttributes(
+            extract_header=lambda _: None,
+            url="https://www.example.com/ok?param=fake",
+            method="POST",
+            status_code=200
+        )
+        result = http_attrs.standardize()
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result["http.url"], "https://www.example.com/ok?param=fake")
+        self.assertEqual(result["http.method"], "POST")
+        self.assertEqual(result["http.status_code"], 200)
+
+    def test_standardize_with_request_id(self):
+        headers = {
+            "X-Request-Id": "MeFirst",
+            "X-Amzn-Trace-Id": "Root=fake"
+        }
+        http_attrs = attributes.HttpAttributes(
+            extract_header=headers.get,
+            url="https://www.example.com/ok?param=fake",
+            method="POST",
+            status_code=200
+        )
+        result = http_attrs.standardize()
+        self.assertEqual(result["http.request_id"], "MeFirst")
+
+        del headers["X-Request-Id"]
+
+        http_attrs = attributes.HttpAttributes(
+            extract_header=headers.get,
+            url="https://www.example.com/ok?param=fake",
+            method="POST",
+            status_code=200
+        )
+
+        result = http_attrs.standardize()
+        self.assertEqual(result["http.request_id"], "Root=fake")

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -21,7 +21,7 @@ class DataDogTestLoggingTestCase(unittest.TestCase):
         self.handler.close()
 
     def test_datadog_handler_called(self):
-         with self.assertLogs('datadog') as cm:
+        with self.assertLogs('datadog') as cm:
             self.handler.send = MagicMock(name='send')
 
             self.logger.addHandler(self.handler)

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,5 +1,8 @@
+import time
 import unittest
 from unittest.mock import Mock
+
+from freezegun import freeze_time
 
 from muselog.django import MuseDjangoRequestLoggingMiddleware
 
@@ -7,16 +10,14 @@ from muselog.django import MuseDjangoRequestLoggingMiddleware
 class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.logger = Mock()
         self.response = Mock()
-        self.response.tell.return_value = 0
+        self.response.tell.return_value = 4
         self.request = self.get_mock_request()
 
         def get_response():
             self.response
 
         self.middleware = MuseDjangoRequestLoggingMiddleware(get_response)
-        self.middleware.set_logger(self.logger)
 
     def get_mock_request(self):
         request = Mock()
@@ -25,16 +26,33 @@ class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
             "HTTP_X_FORWARDED_FOR": "ip1, ip2",
             "REMOTE_ADDR": "ip3"
         }
-        request.headers = request.META
+        request.method = "GET"
+        request.get_raw_uri.return_value = "http://localhost/?someparam=5"
         return request
 
     def test_process_request(self):
-        self.middleware.process_request(self.request)
-        self.assertIsInstance(self.request.started_at, float)
+        with freeze_time("2019-04-05 20:00:02"):
+            self.middleware.process_request(self.request)
+            self.assertEqual(self.request.started_at, time.time())
 
     def test_process_response(self):
-        self.logger.info = Mock()
+        with freeze_time("2019-04-05 20:00:02"):
+            self.request.started_at = time.time()
+
         self.response.status_code = 200
-        self.request.started_at = 0
-        self.middleware.process_response(self.request, self.response)
-        self.logger.info.assert_called_once()
+
+        with self.assertLogs("muselog.util") as cm:
+            with freeze_time("2019-04-05 20:00:03"):
+                self.middleware.process_response(self.request, self.response)
+
+                # Should output a single log record
+                self.assertEqual(len(cm.records), 1)
+
+                # That record should have our extra attributes where available
+                record = cm.records[0].__dict__
+                self.assertEqual(record["duration"], 1000000000)
+                self.assertEqual(record["network.bytes_read"], 0)
+                self.assertEqual(record["network.bytes_written"], 4)
+                self.assertEqual(record["http.url"], "http://localhost/?someparam=5")
+                self.assertEqual(record["http.method"], "GET")
+                self.assertEqual(record["http.status_code"], 200)

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,14 +1,12 @@
 import io
-import json
 import logging
 import time
 import unittest
-from unittest.mock import Mock
 
 from freezegun import freeze_time
 
 import flask
-from flask import g, request
+from flask import g
 from flask.wrappers import Response
 
 from muselog.flask import register_muselog_request_hooks
@@ -18,7 +16,7 @@ class TestCase(unittest.TestCase):
 
     def setUp(self):
         self.output = io.StringIO()
-        self.logger = logging.getLogger("muselog.flask")
+        self.logger = logging.getLogger("muselog.util")
         self.logger.setLevel(logging.INFO)
 
         self.app = flask.Flask(__name__)
@@ -37,7 +35,7 @@ class TestCase(unittest.TestCase):
             resp = Response("Okay", status=200, headers=[("Content-Length", "4")])
 
             with freeze_time("2019-04-03 20:00:02"):
-                with self.assertLogs("muselog.flask") as cm:
+                with self.assertLogs("muselog.util") as cm:
                     self.app.process_response(resp)
 
                     # Should output a single log record
@@ -58,7 +56,7 @@ class TestCase(unittest.TestCase):
                 g.start = time.time()
 
             with freeze_time("2019-04-03 20:00:02"):
-                with self.assertLogs("muselog.flask") as cm:
+                with self.assertLogs("muselog.util") as cm:
                     try:
                         raise Exception("WHO CARES")
                     except Exception as e:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,132 +1,18 @@
 import unittest
 
-from muselog import util
-
-
-class NetworkAttributesTestCase(unittest.TestCase):
-
-    def test_standardize_forward_header_priority(self):
-        headers = {
-            "True-Client-Ip": "123.22.11.59",
-            "Forwarded": "12.22.11.50,54.56.129.12",
-            "X-Forwarded-For": "90.32.53.8,12.22.11.50,54.56.129.12"
-        }
-        network_attrs = util.NetworkAttributes(extract_header=headers.get, remote_addr="99.58.39.5")
-        result = network_attrs.standardize()
-
-        # Prefer cloudflare if available
-        self.assertEqual(result["network.client.ip"], "123.22.11.59")
-
-        del headers["True-Client-Ip"]
-
-        network_attrs = util.NetworkAttributes(extract_header=headers.get, remote_addr="99.58.39.5")
-        result = network_attrs.standardize()
-
-        # Prefer Forwarded if cloudflare unavailable
-        self.assertEqual(result["network.client.ip"], "12.22.11.50")
-
-        del headers["Forwarded"]
-
-        network_attrs = util.NetworkAttributes(extract_header=headers.get, remote_addr="99.58.39.5")
-        result = network_attrs.standardize()
-
-        # Use X-Forwarded-For as last resort before falling back to remote addr
-        self.assertEqual(result["network.client.ip"], "90.32.53.8")
-
-    def test_standardize_without_extra_headers(self):
-        network_attrs = util.NetworkAttributes(
-            extract_header=lambda _: None,
-            remote_addr="99.58.39.5",
-            bytes_read=10,
-            bytes_written=5
-        )
-        result = network_attrs.standardize()
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result["network.client.ip"], "99.58.39.5")
-        self.assertEqual(result["network.bytes_read"], 10)
-        self.assertEqual(result["network.bytes_written"], 5)
-
-    def test_standardize_remote_addr_with_port(self):
-        network_attrs = util.NetworkAttributes(
-            extract_header=lambda _: None,
-            remote_addr="99.58.39.5:80"
-        )
-        result = network_attrs.standardize()
-        self.assertEqual(result["network.client.ip"], "99.58.39.5")
-        self.assertEqual(result["network.client.port"], "80")
-
-    def test_standardize_remote_addr_ipv6(self):
-        network_attrs = util.NetworkAttributes(
-            extract_header=lambda _: None,
-            remote_addr="2001:0db8:85a3:0000:0000:8a2e:0370:7334"
-        )
-        result = network_attrs.standardize()
-        # Should get short form of ipv6 back
-        self.assertEqual(result["network.client.ip"], "2001:db8:85a3::8a2e:370:7334")
-
-    def test_standardize_remote_addr_ipv6_with_port(self):
-        network_attrs = util.NetworkAttributes(
-            extract_header=lambda _: None,
-            remote_addr="[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443"
-        )
-        result = network_attrs.standardize()
-        # Should get short form of ipv6 back, and brackets should be removed.
-        self.assertEqual(result["network.client.ip"], "2001:db8:85a3::8a2e:370:7334")
-        self.assertEqual(result["network.client.port"], "443")
-
-
-class HttpAttributesTestCase(unittest.TestCase):
-
-    def test_standardize_without_extra_headers(self):
-        http_attrs = util.HttpAttributes(
-            extract_header=lambda _: None,
-            url="https://www.example.com/ok?param=fake",
-            method="POST",
-            status_code=200
-        )
-        result = http_attrs.standardize()
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result["http.url"], "https://www.example.com/ok?param=fake")
-        self.assertEqual(result["http.method"], "POST")
-        self.assertEqual(result["http.status_code"], 200)
-
-    def test_standardize_with_request_id(self):
-        headers = {
-            "X-Request-Id": "MeFirst",
-            "X-Amzn-Trace-Id": "Root=fake"
-        }
-        http_attrs = util.HttpAttributes(
-            extract_header=headers.get,
-            url="https://www.example.com/ok?param=fake",
-            method="POST",
-            status_code=200
-        )
-        result = http_attrs.standardize()
-        self.assertEqual(result["http.request_id"], "MeFirst")
-
-        del headers["X-Request-Id"]
-
-        http_attrs = util.HttpAttributes(
-            extract_header=headers.get,
-            url="https://www.example.com/ok?param=fake",
-            method="POST",
-            status_code=200
-        )
-
-        result = http_attrs.standardize()
-        self.assertEqual(result["http.request_id"], "Root=fake")
+from muselog import attributes, util
 
 
 class LogRequestTestCase(unittest.TestCase):
 
     def test_log_request(self):
-        network_attrs = util.NetworkAttributes(
+        network_attrs = attributes.NetworkAttributes(
             extract_header=lambda _: None,
             remote_addr="99.58.39.5",
             bytes_read=10,
             bytes_written=5
         )
-        http_attrs = util.HttpAttributes(
+        http_attrs = attributes.HttpAttributes(
             extract_header={"User-Agent": "Fake", "Referer": "Some Asshole"}.get,
             url="https://www.example.com/ok?param=fake",
             method="GET",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,165 @@
+import unittest
+
+from muselog import util
+
+
+class NetworkAttributesTestCase(unittest.TestCase):
+
+    def test_standardize_forward_header_priority(self):
+        headers = {
+            "True-Client-Ip": "123.22.11.59",
+            "Forwarded": "12.22.11.50,54.56.129.12",
+            "X-Forwarded-For": "90.32.53.8,12.22.11.50,54.56.129.12"
+        }
+        network_attrs = util.NetworkAttributes(extract_header=headers.get, remote_addr="99.58.39.5")
+        result = network_attrs.standardize()
+
+        # Prefer cloudflare if available
+        self.assertEqual(result["network.client.ip"], "123.22.11.59")
+
+        del headers["True-Client-Ip"]
+
+        network_attrs = util.NetworkAttributes(extract_header=headers.get, remote_addr="99.58.39.5")
+        result = network_attrs.standardize()
+
+        # Prefer Forwarded if cloudflare unavailable
+        self.assertEqual(result["network.client.ip"], "12.22.11.50")
+
+        del headers["Forwarded"]
+
+        network_attrs = util.NetworkAttributes(extract_header=headers.get, remote_addr="99.58.39.5")
+        result = network_attrs.standardize()
+
+        # Use X-Forwarded-For as last resort before falling back to remote addr
+        self.assertEqual(result["network.client.ip"], "90.32.53.8")
+
+    def test_standardize_without_extra_headers(self):
+        network_attrs = util.NetworkAttributes(
+            extract_header=lambda _: None,
+            remote_addr="99.58.39.5",
+            bytes_read=10,
+            bytes_written=5
+        )
+        result = network_attrs.standardize()
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result["network.client.ip"], "99.58.39.5")
+        self.assertEqual(result["network.bytes_read"], 10)
+        self.assertEqual(result["network.bytes_written"], 5)
+
+    def test_standardize_remote_addr_with_port(self):
+        network_attrs = util.NetworkAttributes(
+            extract_header=lambda _: None,
+            remote_addr="99.58.39.5:80"
+        )
+        result = network_attrs.standardize()
+        self.assertEqual(result["network.client.ip"], "99.58.39.5")
+        self.assertEqual(result["network.client.port"], "80")
+
+    def test_standardize_remote_addr_ipv6(self):
+        network_attrs = util.NetworkAttributes(
+            extract_header=lambda _: None,
+            remote_addr="2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        )
+        result = network_attrs.standardize()
+        # Should get short form of ipv6 back
+        self.assertEqual(result["network.client.ip"], "2001:db8:85a3::8a2e:370:7334")
+
+    def test_standardize_remote_addr_ipv6_with_port(self):
+        network_attrs = util.NetworkAttributes(
+            extract_header=lambda _: None,
+            remote_addr="[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443"
+        )
+        result = network_attrs.standardize()
+        # Should get short form of ipv6 back, and brackets should be removed.
+        self.assertEqual(result["network.client.ip"], "2001:db8:85a3::8a2e:370:7334")
+        self.assertEqual(result["network.client.port"], "443")
+
+
+class HttpAttributesTestCase(unittest.TestCase):
+
+    def test_standardize_without_extra_headers(self):
+        http_attrs = util.HttpAttributes(
+            extract_header=lambda _: None,
+            url="https://www.example.com/ok?param=fake",
+            method="POST",
+            status_code=200
+        )
+        result = http_attrs.standardize()
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result["http.url"], "https://www.example.com/ok?param=fake")
+        self.assertEqual(result["http.method"], "POST")
+        self.assertEqual(result["http.status_code"], 200)
+
+    def test_standardize_with_request_id(self):
+        headers = {
+            "X-Request-Id": "MeFirst",
+            "X-Amzn-Trace-Id": "Root=fake"
+        }
+        http_attrs = util.HttpAttributes(
+            extract_header=headers.get,
+            url="https://www.example.com/ok?param=fake",
+            method="POST",
+            status_code=200
+        )
+        result = http_attrs.standardize()
+        self.assertEqual(result["http.request_id"], "MeFirst")
+
+        del headers["X-Request-Id"]
+
+        http_attrs = util.HttpAttributes(
+            extract_header=headers.get,
+            url="https://www.example.com/ok?param=fake",
+            method="POST",
+            status_code=200
+        )
+
+        result = http_attrs.standardize()
+        self.assertEqual(result["http.request_id"], "Root=fake")
+
+
+class LogRequestTestCase(unittest.TestCase):
+
+    def test_log_request(self):
+        network_attrs = util.NetworkAttributes(
+            extract_header=lambda _: None,
+            remote_addr="99.58.39.5",
+            bytes_read=10,
+            bytes_written=5
+        )
+        http_attrs = util.HttpAttributes(
+            extract_header={"User-Agent": "Fake", "Referer": "Some Asshole"}.get,
+            url="https://www.example.com/ok?param=fake",
+            method="GET",
+            status_code=301
+        )
+
+        with self.assertLogs("muselog.util") as cm:
+            util.log_request(
+                path="/ok",
+                duration_secs=2,
+                network_attrs=network_attrs,
+                http_attrs=http_attrs,
+                user_id=10
+            )
+
+            # Should output a single log record
+            self.assertEqual(len(cm.records), 1)
+
+            # That record should have our extra attributes where available
+            record = cm.records[0].__dict__
+            self.assertEqual(record["duration"], 2000000000)
+            self.assertEqual(record["network.bytes_read"], 10)
+            self.assertEqual(record["network.bytes_written"], 5)
+            self.assertEqual(record["http.url"], "https://www.example.com/ok?param=fake")
+            self.assertEqual(record["http.method"], "GET")
+            self.assertEqual(record["http.status_code"], 301)
+            self.assertEqual(record["usr.id"], 10)
+
+            # Request summary should include basic information -- not going to care
+            # about the format, so we just check for containment
+            output = cm.output[0]
+            self.assertIn("2000.00ms", output)
+            self.assertIn("301", output)
+            self.assertIn("/ok", output)
+            self.assertIn("99.58.39.5", output)
+            self.assertIn("GET", output)


### PR DESCRIPTION
I did a massive cleanup out of boredom. More important is that I made sure everything is consistent across all middleware, and set up the code to simplify adding new middleware w/o losing consistency.

I also added a preference for 'Forwarded' over 'X-Forwarded-For', though we will encounter the latter more often despite it being non-standard. Note that all these headers are spoofable. They can be used for reporting purposes (few people are going to bother spoofing just to fuck up our logs, heh), but do not rely on them for anything in other libraries.

PLAT-1860