### PR TITLE
Fix logging of  `StreamingHttpResponse` in Django middleware

### DIFF
--- a/muselog/django.py
+++ b/muselog/django.py
@@ -92,7 +92,7 @@ class MuseDjangoRequestLoggingMiddleware:
     @staticmethod
     def _get_bytes_written(response: HttpResponse) -> int:
         """
-        Attemps to get the bytes written, accounting for `StreamingHttpResponse`
+        Attempts to get the bytes written, accounting for `StreamingHttpResponse`
         which will not be able to tell it's position.
         """
         try:

--- a/muselog/django.py
+++ b/muselog/django.py
@@ -63,7 +63,7 @@ class MuseDjangoRequestLoggingMiddleware:
             extract_header=extract_header,
             remote_addr=meta.get("REMOTE_ADDR"),
             bytes_read=meta.get("CONTENT_LENGTH"),
-            bytes_written=self._get_bytes_written()
+            bytes_written=self._get_bytes_written(response)
         )
         http_attrs = attributes.HttpAttributes(
             extract_header=extract_header,

--- a/muselog/django.py
+++ b/muselog/django.py
@@ -63,7 +63,7 @@ class MuseDjangoRequestLoggingMiddleware:
             extract_header=extract_header,
             remote_addr=meta.get("REMOTE_ADDR"),
             bytes_read=meta.get("CONTENT_LENGTH"),
-            bytes_written=response.tell()
+            bytes_written=self._get_bytes_written()
         )
         http_attrs = attributes.HttpAttributes(
             extract_header=extract_header,
@@ -88,3 +88,14 @@ class MuseDjangoRequestLoggingMiddleware:
             return user.id
         else:
             return None
+
+    @staticmethod
+    def _get_bytes_written(response: HttpResponse) -> int:
+        """
+        Attemps to get the bytes written, accounting for `StreamingHttpResponse`
+        which will not be able to tell it's position.
+        """
+        try:
+            return response.tell()
+        except OSError:
+            return 0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.8.4"
+VERSION = "1.8.5"
 
 install_requires = [
     "pygelf>=0.4.1",


### PR DESCRIPTION
### Fix logging of  StreamingHttpResponse in Django middleware

`StreamingHttpResponse` will raise an `OSError` when calling `response.tell()`. Never encountered it before but was working with a `FileResponse` today and ran into it.