### PR TITLE
PLAT-3613 Add context logging + asgi support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.7
     steps:
       - checkout
       - run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: "2.1"
+version: "2.4"
 services:
   test:
-    image: python:3.6
+    image: python:3.7
     command: bash -c "pip install -r test-requirements.txt && python -m unittest"
     working_dir: /muselog
     volumes:

--- a/muselog/asgi.py
+++ b/muselog/asgi.py
@@ -1,0 +1,56 @@
+"""Request logging middleware for any ASGI application."""
+
+import logging
+import time
+from typing import Awaitable, Callable, Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from . import attributes, util
+from .logger import get_logger_with_context
+
+LOGGER: logging.Logger = get_logger_with_context(logging.getLogger(__name__))
+
+RequestResponseEndpoint = Callable[[Request], Awaitable[Response]]
+
+
+def _make_network_attributes(request: Request, response: Optional[Response] = None) -> attributes.NetworkAttributes:
+    return attributes.NetworkAttributes(
+        extract_header=request.headers.get,
+        remote_addr=f"{request.client.host}:{request.client.port}",
+        bytes_read=request.headers.get("Content-Length"),
+        bytes_written=response.headers.get("Content-Length") if response else None
+    )
+
+
+def _make_http_attributes(request: Request, response: Optional[Response] = None) -> attributes.HttpAttributes:
+    return attributes.HttpAttributes(
+        extract_header=request.headers.get,
+        url=str(request.url),
+        method=request.method,
+        status_code=response.status_code if response else 500
+    )
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Log entry and exit point of request, and add request details to the global context."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        util.init_context(request.headers.get)
+        start_time = time.time()
+        try:
+            response = await call_next(request)
+        except Exception:
+            network_attrs = _make_network_attributes(request)
+            http_attrs = _make_http_attributes(request)
+            util.log_request(request.url.path, time.time() - start_time, network_attrs, http_attrs)
+            raise
+
+        network_attrs = _make_network_attributes(request, response)
+        http_attrs = _make_http_attributes(request, response)
+
+        util.log_request(request.url.path, time.time() - start_time, network_attrs, http_attrs)
+
+        return response

--- a/muselog/context.py
+++ b/muselog/context.py
@@ -1,0 +1,39 @@
+"""Manipulate logging context."""
+
+from contextvars import ContextVar
+from typing import Any
+
+#: Context that we can access anywhere in the thread
+_CONTEXT: ContextVar = ContextVar("muselog", default=dict())
+
+
+def copy() -> dict:
+    """Return a copy of the context var for muselog."""
+    return _CONTEXT.get().copy()
+
+
+def get(key: str, default=None) -> Any:
+    """Get a specific key from the context."""
+    return _CONTEXT.get().get(key, default)
+
+
+def clear() -> None:
+    """Clear the context-local context.
+
+    The typical use-case for this function is to invoke it early in request-
+    handling code.
+    """
+    ctx = _CONTEXT.get()
+    ctx.clear()
+
+
+def bind(**kwargs) -> None:
+    """Put keys and values into the context-local context."""
+    _CONTEXT.get().update(kwargs)
+
+
+def unbind(*keys) -> None:
+    """Remove *keys* from the context-local context if they are present."""
+    ctx = _CONTEXT.get()
+    for key in keys:
+        ctx.pop(key, None)

--- a/muselog/flask.py
+++ b/muselog/flask.py
@@ -10,8 +10,9 @@ from flask.wrappers import Response
 from . import attributes, util
 
 
-def _start_request_timer() -> None:
+def _start_request() -> None:
     g.start = time.time()
+    util.init_context(request.headers.get)
 
 
 def _log_request(response: Optional[Response] = None) -> None:
@@ -66,6 +67,6 @@ def register_muselog_request_hooks(app: Flask) -> None:
     ...
     ```
     """
-    app.before_request(_start_request_timer)
+    app.before_request(_start_request)
     app.after_request(_log_request)
     app.teardown_request(_handle_exception)

--- a/muselog/logger.py
+++ b/muselog/logger.py
@@ -1,0 +1,87 @@
+"""Logging Utilities.
+
+This class provides logging utilitis that are meant to be compatible with structlog,
+a Python library for contextual logging. At the moment, we cannot switch over to
+structlog immediately, as it is unclear how it will impact existing muselog integrations.
+"""
+
+import logging
+from typing import Any, Dict, Mapping, Tuple
+
+from . import context
+
+
+#: Keyword argumnts to log emission methods that we should not include in context.
+RESERVED_KWARGS: tuple = ('exc_info', 'stack_info', 'stacklevel', 'extra')
+
+
+class LoggerAdapter(logging.LoggerAdapter):
+    """Adapter that attaches context to log messages automatically."""
+
+    def process(self, msg: str, kwargs: Mapping[str, Any]) -> Tuple[str, Dict[str, Any]]:
+        """Process log message."""
+        ctx = context.copy()
+
+        extra = self._copy_dict_none_to_empty(self.extra)
+        passed_extra = self._copy_dict_none_to_empty(kwargs.get("extra"))
+
+        # Merge contexts, removing them from their respective extras so that we can merge extras.
+        extra_ctx = self._copy_dict_none_to_empty(extra.pop("ctx", None))
+        passed_extra_ctx = self._copy_dict_none_to_empty(passed_extra.pop("ctx", None))
+        extra_ctx.update(passed_extra_ctx)
+        ctx.update(extra_ctx)
+
+        # Merge extras
+        extra.update(passed_extra)
+
+        # Place keyword args (other than the four reserved kwargs) into extra["ctx"]
+        for k, v in kwargs.items():
+            if k in RESERVED_KWARGS:
+                continue
+            ctx[k] = v
+
+        # Remove kwargs that we already have in the context (make sure not to remove reserved kwargs)
+        for k, _ in ctx.items():
+            if k in kwargs and k not in RESERVED_KWARGS:
+                del kwargs[k]
+
+        # Add context
+        if ctx:
+            extra["ctx"] = ctx
+
+        # If extra has contents, add it back to kwargs
+        if extra:
+            kwargs["extra"] = extra
+
+        return msg, kwargs
+
+    def bind(self, **new_ctx) -> "LoggerAdapter":
+        """Create a copy of the logger with provided context merged into existing context."""
+        extra = self._copy_dict_none_to_empty(self.extra)
+        ctx = self._copy_dict_none_to_empty(extra.get("ctx"))
+        ctx.update(new_ctx)
+        extra["ctx"] = ctx
+        return LoggerAdapter(self.logger, extra)
+
+    def unbind(self, *keys) -> "LoggerAdapter":
+        """Create a copy of the logger with provided context keys removed from existing context."""
+        extra = self._copy_dict_none_to_empty(self.extra)
+        ctx = self._copy_dict_none_to_empty(extra.get("ctx"))
+        extra["ctx"] = {k: v for k, v in ctx.items() if k not in keys}
+        return LoggerAdapter(self.logger, extra)
+
+    def new(self, **ctx) -> "LoggerAdapter":
+        """Return a new logger with only the specified context included."""
+        extra = self._copy_dict_none_to_empty(self.extra)
+        if "ctx" in extra:
+            del extra["ctx"]
+        return LoggerAdapter(self.logger, extra).bind(**ctx)
+
+    @staticmethod
+    def _copy_dict_none_to_empty(orig: Mapping[str, Any]) -> Dict[str, Any]:
+        return dict(orig) if orig is not None else dict()
+
+
+def get_logger_with_context(logger: logging.Logger, **ctx) -> LoggerAdapter:
+    """Get a logger that always adds `ctx` to its log records."""
+    return LoggerAdapter(logger, dict(ctx=ctx))

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "2.0.2"
+VERSION = "2.1.0"
 
 install_requires = [
     "JSON-log-formatter>=0.2.0",
@@ -19,6 +19,7 @@ setup(
     extras_require={
         "django": ["Django>=2.2.12"],
         "flask": ["Flask>=1.0.2"],
-        "tornado": ["tornado>=4.5.1"]
+        "tornado": ["tornado>=4.5.1"],
+        "asgi": ["starlette>=0.13.6"]
     }
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,8 @@
 freezegun==0.3.11
 Flask==1.0.2
 Django==2.2.12
+requests==2.24.0
+starlette==0.13.6
 tornado==4.5.1
 
 ddtrace==0.22.0

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,9 @@
+from muselog import context
+
+
+class ClearContext:
+    """Clear context after test finishes."""
+
+    def tearDown(self) -> None:
+        context.clear()
+        super().tearDown()

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -1,0 +1,66 @@
+import unittest
+
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+
+from muselog import asgi
+
+from .support import ClearContext
+
+
+class ASGIRequestLoggingMiddlewareTestCase(ClearContext, unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.app = Starlette()
+        self.app.add_middleware(asgi.RequestLoggingMiddleware)
+        self.client = TestClient(self.app)
+
+    def test_happy(self) -> None:
+        """Test that the middleware emits populated log record."""
+
+        @self.app.route("/")
+        def homepage(request):
+            return PlainTextResponse("x" * 4000, status_code=202)
+
+        with self.assertLogs("muselog.util") as cm:
+            self.client.get("/?someparam=10")
+
+            # Should output a single log record
+            self.assertEqual(len(cm.records), 1)
+
+            # That record should have our extra attributes where available
+            record = cm.records[0].__dict__
+            self.assertTrue("duration" in record)
+            self.assertTrue("http.request_id" in record)
+            self.assertEqual(record["network.bytes_read"], 0)
+            self.assertEqual(record["network.bytes_written"], 4000)
+            self.assertEqual(record["http.url"], "http://testserver/?someparam=10")
+            self.assertEqual(record["http.method"], "GET")
+            self.assertEqual(record["http.status_code"], 202)
+
+    def test_exception(self) -> None:
+        """Test that the middleware logs exceptions."""
+
+        @self.app.route("/")
+        def rekt(request):
+            raise Exception("Oh no.")
+
+        with self.assertLogs("muselog.util", "ERROR") as cm:
+            with self.assertRaises(Exception):
+                self.client.get("/")
+
+            # Should output a single log record
+            self.assertEqual(len(cm.records), 1)
+
+            # That record should have our extra attributes where available
+            record = cm.records[0].__dict__
+            self.assertTrue("duration" in record)
+            self.assertTrue("http.request_id" in record)
+            self.assertEqual(record["network.bytes_read"], 0)
+            self.assertEqual(record["network.bytes_written"], 0)
+            self.assertEqual(record["http.url"], "http://testserver/")
+            self.assertEqual(record["http.method"], "GET")
+            self.assertEqual(record["http.status_code"], 500)

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -2,8 +2,10 @@ import unittest
 
 from muselog import attributes
 
+from .support import ClearContext
 
-class NetworkAttributesTestCase(unittest.TestCase):
+
+class NetworkAttributesTestCase(ClearContext, unittest.TestCase):
 
     def test_standardize_forward_header_priority(self):
         headers = {
@@ -75,7 +77,7 @@ class NetworkAttributesTestCase(unittest.TestCase):
         self.assertEqual(result["network.client.port"], "443")
 
 
-class HttpAttributesTestCase(unittest.TestCase):
+class HttpAttributesTestCase(ClearContext, unittest.TestCase):
 
     def test_standardize_without_extra_headers(self):
         http_attrs = attributes.HttpAttributes(

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -9,16 +9,20 @@ from freezegun import freeze_time
 
 from muselog.datadog import DataDogUdpHandler, DatadogJSONFormatter
 
+from .support import ClearContext
 
-class DataDogTestLoggingTestCase(unittest.TestCase):
+
+class DataDogTestLoggingTestCase(ClearContext, unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         self.handler = DataDogUdpHandler(host="127.0.0.1", port=10518)
         self.logger = logging.getLogger('datadog')
 
     def tearDown(self):
         self.logger.removeHandler(self.handler)
         self.handler.close()
+        super().tearDown()
 
     def test_datadog_handler_called(self):
         with self.assertLogs('datadog') as cm:
@@ -33,7 +37,7 @@ class DataDogTestLoggingTestCase(unittest.TestCase):
             self.assertEqual(cm.output, ['WARNING:datadog:Datadog msg'])
 
 
-class InjectTraceValuesTestCase(unittest.TestCase):
+class InjectTraceValuesTestCase(ClearContext, unittest.TestCase):
     """Tests code related to injecting logs with a trace and span id."""
 
     def setUp(self):

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -6,10 +6,13 @@ from freezegun import freeze_time
 
 from muselog.django import MuseDjangoRequestLoggingMiddleware
 
+from .support import ClearContext
 
-class MuseDjangoRequestLoggingMiddlewareTestCase(unittest.TestCase):
+
+class MuseDjangoRequestLoggingMiddlewareTestCase(ClearContext, unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         self.response = Mock()
         self.response.tell.return_value = 4
         self.request = self.get_mock_request()

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -11,10 +11,14 @@ from flask.wrappers import Response
 
 from muselog.flask import register_muselog_request_hooks
 
+from .support import ClearContext
 
-class TestCase(unittest.TestCase):
+
+class FlaskMiddlewareTestCase(ClearContext, unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
+
         self.output = io.StringIO()
         self.logger = logging.getLogger("muselog.util")
         self.logger.setLevel(logging.INFO)
@@ -26,6 +30,7 @@ class TestCase(unittest.TestCase):
     def tearDown(self):
         self.logger.handlers = []
         self.output.close()
+        super().tearDown()
 
     def test_happy(self):
         with self.app.test_request_context("/?someparam=5"):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,139 @@
+"""Test the context-enabled log adapter."""
+
+import logging
+import unittest
+
+from muselog import context
+from muselog.logger import get_logger_with_context
+
+from .support import ClearContext
+
+LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+class LoggerTestCase(ClearContext, unittest.TestCase):
+    """Tests for the contextual logging functionality."""
+
+    def test_empty_ctx(self) -> None:
+        """Test that logging without any context does not populate the 'ctx' object."""
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER)
+            logger.info("Test")
+            self.assertEqual(len(log.records), 1)
+            self.assertFalse(hasattr(log.records[0], "ctx"))
+
+    def test_default_context(self) -> None:
+        """Test that logging with a default context provides that context in the 'ctx' object."""
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER, testing="Sandwich")
+            logger.info("Test")
+            self.assertEqual(len(log.records), 1)
+            self.assertEqual(log.records[0].ctx, dict(testing="Sandwich"))
+
+    def test_provided_context(self) -> None:
+        """Test that logging with a provided context results in that provided context in the 'ctx' object."""
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER)
+            logger.info("Test", testing="Hello")
+            self.assertEqual(len(log.records), 1)
+            self.assertEqual(log.records[0].ctx, dict(testing="Hello"))
+
+    def test_merged_context(self) -> None:
+        """Test that logging with both a default and provided context merges the contexts."""
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER, testing="Sandwich")
+            # Test no conflict
+            logger.info("Test", testing1="Hello")
+
+            # Test conflict (testing appears in custom and default context)
+            logger.info("Test2", testing="Not Sandwich", testing2="Test")
+
+            self.assertEqual(len(log.records), 2)
+            self.assertEqual(log.records[0].ctx, dict(testing="Sandwich", testing1="Hello"))
+            self.assertEqual(log.records[1].ctx, dict(testing="Not Sandwich", testing2="Test"))
+
+    def test_ignore_reserved_kwargs(self) -> None:
+        """Test that the logger does not include reserved kwargs in the context, and should not remove these keywords from the record."""
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER)
+            logger.info("Test", stack_info=True, testing="Testing")
+            self.assertEqual(len(log.records), 1)
+            self.assertEqual(log.records[0].ctx, dict(testing="Testing"))
+
+    def test_merge_extra(self) -> None:
+        """Test that the logger extracts context from 'extra' arg and merges it into the primary context."""
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER, testing1="Testing1")
+            logger.info("Test", testing="Testing", extra=dict(ctx=dict(testing2="Testing2"), other=5))
+            self.assertEqual(len(log.records), 1)
+            self.assertEqual(log.records[0].other, 5)
+            self.assertEqual(log.records[0].ctx, dict(testing="Testing", testing1="Testing1", testing2="Testing2"))
+
+    def test_bind(self) -> None:
+        """Test that bind adds new context."""
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER, testing1="Testing1")
+            logger = logger.bind(testing2="Testing2")
+            logger.info("Test2")
+            logger = logger.bind(testing3="Testing3")
+            logger.info("Test3")
+            self.assertEqual(len(log.records), 2)
+            self.assertEqual(log.records[0].ctx, dict(testing1="Testing1", testing2="Testing2"))
+            self.assertEqual(log.records[1].ctx, dict(testing1="Testing1", testing2="Testing2", testing3="Testing3"))
+
+    def test_unbind(self) -> None:
+        """Test that unbind removes specified context."""
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER, testing1="Testing1")
+            logger = logger.bind(testing2="Testing2")
+            logger.info("Test2")
+            logger = logger.unbind("testing2", "testing3")
+            logger.info("Test3")
+            self.assertEqual(len(log.records), 2)
+            self.assertEqual(log.records[0].ctx, dict(testing1="Testing1", testing2="Testing2"))
+            self.assertEqual(log.records[1].ctx, dict(testing1="Testing1"))
+
+    def test_new(self) -> None:
+        """Test that new replaces original context with specified context."""
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER, testing1="Testing1")
+            logger = logger.new(testing2="Testing2")
+            logger.info("Test2")
+            self.assertEqual(len(log.records), 1)
+            self.assertEqual(log.records[0].ctx, dict(testing2="Testing2"))
+
+    def test_bind_global(self) -> None:
+        """Test that global context is always added."""
+        context.bind(testing="Testing", testing1="Override")
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER, testing2="Testing2")
+            logger.info("First Test")
+            logger = logger.bind(testing1="Testing1")
+            logger.info("Second Test")
+            self.assertEqual(len(log.records), 2)
+            self.assertEqual(log.records[0].ctx, dict(testing="Testing", testing1="Override", testing2="Testing2"))
+            self.assertEqual(log.records[1].ctx, dict(testing="Testing", testing1="Testing1", testing2="Testing2"))
+
+    def test_unbind_global(self) -> None:
+        """Test that global context is removed."""
+        context.bind(testing="Testing", testing1="Remove")
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER)
+            logger.info("First Test")
+            context.unbind("testing1")
+            logger.info("Second Test")
+            self.assertEqual(len(log.records), 2)
+            self.assertEqual(log.records[0].ctx, dict(testing="Testing", testing1="Remove"))
+            self.assertEqual(log.records[1].ctx, dict(testing="Testing"))
+
+    def test_clear_global(self) -> None:
+        """Test that global context is cleared."""
+        context.bind(testing1="Remove1", testing2="Remove2")
+        with self.assertLogs(__name__) as log:
+            logger = get_logger_with_context(LOGGER, testing3="Stay")
+            logger.info("First Test")
+            context.clear()
+            logger.info("Second Test")
+            self.assertEqual(len(log.records), 2)
+            self.assertEqual(log.records[0].ctx, dict(testing1="Remove1", testing2="Remove2", testing3="Stay"))
+            self.assertEqual(log.records[1].ctx, dict(testing3="Stay"))

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -3,8 +3,10 @@ import unittest
 
 import muselog
 
+from .support import ClearContext
 
-class SetupLoggingTestCase(unittest.TestCase):
+
+class SetupLoggingTestCase(ClearContext, unittest.TestCase):
 
     def test_defaults(self):
         logging.getLogger().setLevel(logging.INFO)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,8 +2,10 @@ import unittest
 
 from muselog import attributes, util
 
+from .support import ClearContext
 
-class LogRequestTestCase(unittest.TestCase):
+
+class UtilTestCase(ClearContext, unittest.TestCase):
 
     def test_log_request(self):
         network_attrs = attributes.NetworkAttributes(


### PR DESCRIPTION
Adds the context logger (which forces us to python 3.7, which should be fine for all services that use muselog and are actively developed) and ASGI middleware to log requests. ASGI middleware will work on any web framework that implements ASGI, e.g., Starlette, FastAPI, Quart, and Django (3.0+).

PLAT-3613