### PR TITLE
update ddtrace version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "2.3.2"
+VERSION = "2.4.0"
 
 install_requires = [
     "JSON-log-formatter>=0.2.0",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ VERSION = "2.3.2"
 
 install_requires = [
     "JSON-log-formatter>=0.2.0",
-    "ddtrace>=0.22.0",  # This is the minimum version allowed as trace helpers weren't added until 0.22.0
+    "ddtrace>=1.3.2",  # Let's leap ahead 
     "typer>=0.3.0"
 ]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,5 +5,5 @@ requests==2.24.0
 starlette==0.13.6
 tornado==4.5.1
 
-ddtrace==0.22.0
+ddtrace==1.3.2
 JSON-log-formatter==0.1.0


### PR DESCRIPTION
update to use current version of ddtrace, which necessitates [updating deprecated method](https://ddtrace.readthedocs.io/en/stable/release_notes.html#:~:text=The%20deprecated%20method%20ddtrace.helpers.get_correlation_ids%20is%20removed.%20Use%20ddtrace.Tracer.get_log_correlation_context()%20instead):
