### PR TITLE
Muselog error on profiles

### DIFF
--- a/muselog/commands/muselog_run.py
+++ b/muselog/commands/muselog_run.py
@@ -26,6 +26,11 @@ def _validate_module_log_level(ctx, param, value):
             if not module or not log_level:
                 raise ValueError
             _ = LogLevel[log_level.lower()]
+    except TypeError:
+        if value is None:
+            raise typer.BadParameter("log levels cannot be None")
+        else:
+            raise typer.BadParameter("format must be module=DEBUG|INFO|WARNING|ERROR|CRITICAL")
     except ValueError:
         raise typer.BadParameter("format must be module=DEBUG|INFO|WARNING|ERROR|CRITICAL")
     except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "2.5.1"
+VERSION = "2.5.2"
 
 install_requires = [
     "JSON-log-formatter>=0.2.0",


### PR DESCRIPTION
Trying to fix:
```
Traceback (most recent call last):

  File "/usr/local/bin/muselog-run", line 8, in <module>
    sys.exit(app())

  File "/usr/local/lib/python3.8/site-packages/muselog/commands/muselog_run.py", line 24, in _validate_module_log_level
    for module_log_level in value:

TypeError: 'NoneType' object is not iterable
```